### PR TITLE
Scc 3265

### DIFF
--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -1,57 +1,122 @@
 {
-  "title": {
+  "type": {
     "paths": [
       {
-        "marc": "245",
-        "subfields": [
-          "a",
-          "b"
-        ],
-        "nyplSources": [
-          "sierra-nypl",
-          "recap-cul",
-          "recap-pul"
-        ]
-      },
+        "marc": "LDR/07"
+      }
+    ]
+  },
+  "aeonURL": {
+    "paths": [
       {
-        "marc": "245",
+        "notes": "856 $u matching Aeon base URLs"
+      }
+    ]
+  },
+  "alternativeTitle": {
+    "paths": [
+      {
+        "marc": "210",
         "subfields": [
           "a",
           "b",
-          "c"
-        ],
-        "nyplSources": [
-          "recap-hl"
+          "f",
+          "n",
+          "p"
+        ]
+      },
+      {
+        "marc": "222",
+        "subfields": [
+          "a",
+          "b",
+          "f",
+          "n",
+          "p"
+        ]
+      },
+      {
+        "marc": "240",
+        "subfields": [
+          "a",
+          "b",
+          "f",
+          "n",
+          "p"
+        ]
+      },
+      {
+        "marc": "246",
+        "subfields": [
+          "a",
+          "b",
+          "f",
+          "n",
+          "p"
+        ]
+      },
+      {
+        "marc": "740",
+        "subfields": [
+          "a",
+          "n",
+          "p"
+        ]
+      },
+      {
+        "marc": "793",
+        "excludedSubfields": [
+          "0",
+          "6"
         ]
       }
     ]
   },
-  "creatorLiteral": {
+  "callNumber": {
     "paths": [
       {
-        "marc": "100",
+        "marc": "852",
+        "subfields": [
+          "h"
+        ]
+      }
+    ]
+  },
+  "catalogBibLocationCode": {
+    "paths": [
+      {
+        "marc": "locations.code"
+      }
+    ]
+  },
+  "contents": {
+    "paths": [
+      {
+        "marc": "505",
         "subfields": [
           "a",
-          "b",
-          "c",
-          "q",
-          "d",
-          "j"
+          "g",
+          "r",
+          "t"
         ]
-      },
+      }
+    ]
+  },
+  "contentsTitle": {
+    "paths": [
       {
-        "marc": "110",
-        "excludedSubfields": [
-          "0",
-          "6"
+        "marc": "505",
+        "subfields": [
+          "t"
         ]
-      },
+      }
+    ]
+  },
+  "carrierType": {
+    "paths": [
       {
-        "marc": "111",
-        "excludedSubfields": [
-          "0",
-          "6"
-        ]
+        "notes": "see mapping tab \"Media and Carrier type mappings\"",
+        "description": "Specific Material Designation"
       }
     ]
   },
@@ -98,12 +163,1190 @@
       }
     ]
   },
-  "contentsTitle": {
+  "contributorLiteralByRole": {
     "paths": [
       {
-        "marc": "505",
+        "marc": "700",
         "subfields": [
+          "a",
+          "b",
+          "c",
+          "q",
+          "d",
+          "j"
+        ]
+      },
+      {
+        "marc": "710"
+      },
+      {
+        "marc": "711"
+      }
+    ]
+  },
+  "creatorLiteral": {
+    "paths": [
+      {
+        "marc": "100",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "q",
+          "d",
+          "j"
+        ]
+      },
+      {
+        "marc": "110",
+        "excludedSubfields": [
+          "0",
+          "6"
+        ]
+      },
+      {
+        "marc": "111",
+        "excludedSubfields": [
+          "0",
+          "6"
+        ]
+      }
+    ]
+  },
+  "date": {
+    "paths": [
+      {
+        "marc": "publishYear"
+      }
+    ]
+  },
+  "dateCreated": {
+    "paths": [
+      {
+        "marc": "publishYear"
+      }
+    ]
+  },
+  "dateEnd": {
+    "paths": [
+      {
+        "marc": "008/11-14"
+      }
+    ]
+  },
+  "dateStart": {
+    "paths": [
+      {
+        "marc": "008/7-10"
+      }
+    ]
+  },
+  "datesOfSerialPublication": {
+    "paths": [
+      {
+        "marc": "362",
+        "subfields": [
+          "a",
+          "z"
+        ]
+      }
+    ]
+  },
+  "description": {
+    "paths": [
+      {
+        "marc": "520",
+        "subfields": [
+          "a"
+        ],
+        "description": "Summary, Etc."
+      }
+    ]
+  },
+  "dimensions": {
+    "paths": [
+      {
+        "marc": "300",
+        "subfields": [
+          "c"
+        ]
+      }
+    ]
+  },
+  "donorSponsor": {
+    "paths": [
+      {
+        "marc": "799",
+        "excludedSubfields": [
+          "0",
+          "6"
+        ]
+      }
+    ]
+  },
+  "editionStatement": {
+    "paths": [
+      {
+        "marc": "250",
+        "excludedSubfields": [
+          "0",
+          "6"
+        ]
+      }
+    ]
+  },
+  "electronicLocation": {
+    "paths": [
+      {
+        "notes": "856 (see notes)"
+      }
+    ]
+  },
+  "extent": {
+    "paths": [
+      {
+        "marc": "300",
+        "subfields": [
+          "a",
+          "b"
+        ]
+      }
+    ]
+  },
+  "formerTitle": {
+    "paths": [
+      {
+        "marc": "247",
+        "subfields": [
+          "a",
+          "b",
+          "f",
+          "g",
+          "n",
+          "p"
+        ]
+      }
+    ]
+  },
+  "genreFormLiteral": {
+    "paths": [
+      {
+        "marc": "655",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Genre/Form literal"
+      }
+    ]
+  },
+  "identifier": {
+    "paths": [
+      {
+        "notes": "Other Standard Identifier (LCCN?) (Canceled)",
+        "marc": "024",
+        "subfields": [
+          "z"
+        ]
+      },
+      {
+        "notes": "Report No.",
+        "marc": "027",
+        "subfields": [
+          "a"
+        ]
+      },
+      {
+        "notes": "Report No. (Canceled)",
+        "marc": "027",
+        "subfields": [
+          "z"
+        ]
+      },
+      {
+        "notes": "Publisher No.",
+        "marc": "028",
+        "subfields": [
+          "a",
+          "b"
+        ]
+      },
+      {
+        "notes": "System Control Number",
+        "marc": "035",
+        "subfields": [
+          "a"
+        ]
+      },
+      {
+        "notes": "System Control Number (Canceled)",
+        "marc": "035",
+        "subfields": [
+          "z"
+        ]
+      },
+      {
+        "marc": "086",
+        "notes": "Government Document Classification Number",
+        "subfields": [
+          "a"
+        ]
+      },
+      {
+        "marc": "086",
+        "notes": "Government Document Classification Number (Canceled)",
+        "subfields": [
+          "z"
+        ]
+      },
+      {
+        "marc": "074",
+        "notes": "GPO Item Number",
+        "subfields": [
+          "a"
+        ]
+      },
+      {
+        "marc": "074",
+        "notes": "GPO Item Number (Canceled)",
+        "subfields": [
+          "z"
+        ]
+      }
+    ]
+  },
+  "isbn": {
+    "paths": [
+      {
+        "marc": "020",
+        "subfields": [
+          "a"
+        ]
+      }
+    ]
+  },
+  "isbnCanceledInvalid": {
+    "paths": [
+      {
+        "marc": "020",
+        "subfields": [
+          "z"
+        ]
+      }
+    ]
+  },
+  "issn": {
+    "paths": [
+      {
+        "marc": "022",
+        "subfields": [
+          "a"
+        ]
+      }
+    ]
+  },
+  "issnCanceled": {
+    "paths": [
+      {
+        "marc": "022",
+        "subfields": [
+          "z"
+        ]
+      }
+    ]
+  },
+  "issnIncorrect": {
+    "paths": [
+      {
+        "marc": "022",
+        "subfields": [
+          "y"
+        ]
+      }
+    ]
+  },
+  "issuance": {
+    "paths": [
+      {
+        "notes": "bibLevel.code (bibLevel.value for prefLabel)"
+      }
+    ]
+  },
+  "label": {},
+  "language": {
+    "paths": [
+      {
+        "marc": "lang",
+        "description": "Language  "
+      },
+      {
+        "marc": "OR 008/35-37",
+        "description": "Language  "
+      },
+      {
+        "marc": "OR 041",
+        "subfields": [
+          "a"
+        ],
+        "description": "Language  "
+      }
+    ]
+  },
+  "lccClassification": {
+    "paths": [
+      {
+        "marc": "050",
+        "subfields": [
+          "a",
+          "b",
+          "c"
+        ]
+      }
+    ]
+  },
+  "lccn": {
+    "paths": [
+      {
+        "marc": "010",
+        "subfields": [
+          "a"
+        ]
+      },
+      {
+        "marc": "024",
+        "subfields": [
+          "a"
+        ]
+      }
+    ]
+  },
+  "mediaType": {
+    "paths": [
+      {
+        "notes": "337 $b ($a for prefLabel)"
+      }
+    ]
+  },
+  "note": {
+    "paths": [
+      {
+        "marc": "500",
+        "subfields": [
+          "a"
+        ],
+        "description": "Note"
+      },
+      {
+        "marc": "501",
+        "subfields": [
+          "a"
+        ],
+        "description": "With"
+      },
+      {
+        "marc": "502",
+        "subfields": [
+          "a"
+        ],
+        "description": "Thesis"
+      },
+      {
+        "marc": "504",
+        "subfields": [
+          "a"
+        ],
+        "description": "Bibliography"
+      },
+      {
+        "marc": "506",
+        "subfields": [
+          "a"
+        ],
+        "description": "Access"
+      },
+      {
+        "marc": "507",
+        "subfields": [
+          "a"
+        ],
+        "description": "Scale"
+      },
+      {
+        "marc": "508",
+        "subfields": [
+          "a"
+        ],
+        "description": "Credits"
+      },
+      {
+        "marc": "510",
+        "subfields": [
+          "a"
+        ],
+        "description": "Indexed In"
+      },
+      {
+        "marc": "511",
+        "subfields": [
+          "a"
+        ],
+        "description": "Performer"
+      },
+      {
+        "marc": "513",
+        "subfields": [
+          "a"
+        ],
+        "description": "Type of Report"
+      },
+      {
+        "marc": "514",
+        "subfields": [
+          "a"
+        ],
+        "description": "Data Quality"
+      },
+      {
+        "marc": "515",
+        "subfields": [
+          "a"
+        ],
+        "description": "Numbering"
+      },
+      {
+        "marc": "516",
+        "subfields": [
+          "a"
+        ],
+        "description": "File Type"
+      },
+      {
+        "marc": "518",
+        "subfields": [
+          "a"
+        ],
+        "description": "Event"
+      },
+      {
+        "marc": "521",
+        "subfields": [
+          "a"
+        ],
+        "description": "Audience"
+      },
+      {
+        "marc": "522",
+        "subfields": [
+          "a"
+        ],
+        "description": "Coverage"
+      },
+      {
+        "marc": "524",
+        "subfields": [
+          "a"
+        ],
+        "description": "Cite As"
+      },
+      {
+        "marc": "525",
+        "subfields": [
+          "a"
+        ],
+        "description": "Supplement"
+      },
+      {
+        "marc": "526",
+        "subfields": [
+          "a"
+        ],
+        "description": "Study Program"
+      },
+      {
+        "marc": "530",
+        "subfields": [
+          "a"
+        ],
+        "description": "Additional Formats"
+      },
+      {
+        "marc": "533",
+        "subfields": [
+          "a"
+        ],
+        "description": "Reproduction"
+      },
+      {
+        "marc": "534",
+        "subfields": [
+          "a"
+        ],
+        "description": "Original Version"
+      },
+      {
+        "marc": "535",
+        "subfields": [
+          "a"
+        ],
+        "description": "Original Location"
+      },
+      {
+        "marc": "536",
+        "subfields": [
+          "a"
+        ],
+        "description": "Funding"
+      },
+      {
+        "marc": "538",
+        "subfields": [
+          "a"
+        ],
+        "description": "System Details"
+      },
+      {
+        "marc": "540",
+        "subfields": [
+          "a"
+        ],
+        "description": "Terms of Use"
+      },
+      {
+        "marc": "541",
+        "subfields": [
+          "a"
+        ],
+        "description": "Source"
+      },
+      {
+        "marc": "542",
+        "subfields": [
+          "a"
+        ],
+        "description": "Information Relating to Copyright Status"
+      },
+      {
+        "marc": "544",
+        "subfields": [
+          "a"
+        ],
+        "description": "Location of Other Archival Materials"
+      },
+      {
+        "marc": "545",
+        "subfields": [
+          "a"
+        ],
+        "description": "Biography"
+      },
+      {
+        "marc": "546",
+        "subfields": [
+          "a"
+        ],
+        "description": "Language"
+      },
+      {
+        "marc": "547",
+        "subfields": [
+          "a"
+        ],
+        "description": "Former Title"
+      },
+      {
+        "marc": "550",
+        "subfields": [
+          "a"
+        ],
+        "description": "Issued By"
+      },
+      {
+        "marc": "555",
+        "subfields": [
+          "a"
+        ],
+        "description": "Indexes/Finding Aids"
+      },
+      {
+        "marc": "556",
+        "subfields": [
+          "a"
+        ],
+        "description": "Documentation"
+      },
+      {
+        "marc": "561",
+        "subfields": [
+          "a"
+        ],
+        "description": "Provenance"
+      },
+      {
+        "marc": "562",
+        "subfields": [
+          "a"
+        ],
+        "description": "Copy/Version"
+      },
+      {
+        "marc": "563",
+        "subfields": [
+          "a"
+        ],
+        "description": "Binding"
+      },
+      {
+        "marc": "580",
+        "subfields": [
+          "a"
+        ],
+        "description": "Linking Entry"
+      },
+      {
+        "marc": "581",
+        "subfields": [
+          "a"
+        ],
+        "description": "Publications"
+      },
+      {
+        "marc": "583",
+        "subfields": [
+          "a"
+        ],
+        "description": "Processing Action"
+      },
+      {
+        "marc": "585",
+        "subfields": [
+          "a"
+        ],
+        "description": "Exhibitions"
+      },
+      {
+        "marc": "586",
+        "subfields": [
+          "a"
+        ],
+        "description": "Awards"
+      },
+      {
+        "marc": "588",
+        "subfields": [
+          "a"
+        ],
+        "description": "Source of Description"
+      }
+    ]
+  },
+  "oclcNumber": {
+    "paths": [
+      {
+        "marc": "991",
+        "subfields": [
+          "y"
+        ]
+      },
+      {
+        "marc": "035",
+        "subfields": [
+          "a"
+        ],
+        "notes": "Reject if not prefixed '(OCoLC)'"
+      },
+      {
+        "marc": "001"
+      }
+    ]
+  },
+  "Part of": {
+    "paths": [
+      {
+        "marc": "773",
+        "subfields": [
+          "i",
+          "a",
+          "s",
+          "t",
+          "b",
+          "m",
+          "d",
+          "h",
+          "k",
+          "n",
+          "g",
+          "r",
+          "u",
+          "x",
+          "y",
+          "z",
+          "w",
+          "3",
+          "7"
+        ]
+      }
+    ]
+  },
+  "placeOfPublication": {
+    "paths": [
+      {
+        "marc": "260",
+        "subfields": [
+          "a"
+        ]
+      },
+      {
+        "marc": "264",
+        "subfields": [
+          "a"
+        ]
+      }
+    ]
+  },
+  "publicationStatement": {
+    "paths": [
+      {
+        "marc": "260",
+        "subfields": [
+          "a",
+          "b",
+          "c"
+        ]
+      },
+      {
+        "marc": "264",
+        "subfields": [
+          "a",
+          "b",
+          "c"
+        ]
+      }
+    ]
+  },
+  "publisherLiteral": {
+    "paths": [
+      {
+        "marc": "260",
+        "subfields": [
+          "b"
+        ]
+      },
+      {
+        "marc": "264",
+        "subfields": [
+          "b"
+        ]
+      }
+    ]
+  },
+  "resourceType": {
+    "paths": [
+      {
+        "marc": "fixedFields.label = \"Material type\""
+      }
+    ]
+  },
+  "seriesStatement": {
+    "paths": [
+      {
+        "marc": "440",
+        "subfields": [
+          "3",
+          "a",
+          "x",
+          "v",
+          "l"
+        ]
+      },
+      {
+        "marc": "490",
+        "subfields": [
+          "3",
+          "a",
+          "x",
+          "v",
+          "l"
+        ]
+      },
+      {
+        "marc": "800",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "f",
+          "g",
+          "h",
+          "i",
+          "j",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "q",
+          "r",
+          "s",
+          "t",
+          "u",
+          "v"
+        ]
+      },
+      {
+        "marc": "810",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "f",
+          "g",
+          "h",
+          "i",
+          "j",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "q",
+          "r",
+          "s",
+          "t",
+          "u",
+          "v"
+        ]
+      },
+      {
+        "marc": "811",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "f",
+          "g",
+          "h",
+          "i",
+          "j",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "q",
+          "r",
+          "s",
+          "t",
+          "u",
+          "v"
+        ]
+      }
+    ]
+  },
+  "subjectLiteral": {
+    "paths": [
+      {
+        "marc": "600",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "g",
+          "4",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Subject Added Entry-Personal Name"
+      },
+      {
+        "marc": "610",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "g",
+          "4",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Subject Added Entry-Personal Name"
+      },
+      {
+        "marc": "611",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "g",
+          "4",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Subject Added Entry-Personal Name"
+      },
+      {
+        "marc": "630",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "g",
+          "4",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Subject Added Entry-Personal Name"
+      },
+      {
+        "marc": "648",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "g",
+          "4",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Subject Added Entry-Personal Name"
+      },
+      {
+        "marc": "650",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "g",
+          "4",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Subject Added Entry-Personal Name"
+      },
+      {
+        "marc": "651",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "g",
+          "4",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Subject Added Entry-Personal Name"
+      },
+      {
+        "marc": "653",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "g",
+          "4",
+          "v",
+          "x",
+          "y",
+          "z"
+        ],
+        "description": "Subject Added Entry-Personal Name"
+      }
+    ]
+  },
+  "supplementaryContent": {
+    "paths": [
+      {
+        "marc": "856 (see notes)"
+      }
+    ]
+  },
+  "suppressed": {
+    "paths": [
+      {
+        "marc": "suppressed"
+      }
+    ]
+  },
+  "title": {
+    "paths": [
+      {
+        "marc": "245",
+        "subfields": [
+          "a",
+          "b"
+        ],
+        "nyplSources": [
+          "sierra-nypl",
+          "recap-cul",
+          "recap-pul"
+        ]
+      },
+      {
+        "marc": "245",
+        "subfields": [
+          "a",
+          "b",
+          "c"
+        ],
+        "nyplSources": [
+          "recap-hl"
+        ]
+      }
+    ]
+  },
+  "uniformTitle": {
+    "paths": [
+      {
+        "marc": "130",
+        "subfields": [
+          "a",
+          "d",
+          "f",
+          "g",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "r",
+          "s",
           "t"
+        ]
+      },
+      {
+        "marc": "240",
+        "subfields": [
+          "a",
+          "d",
+          "f",
+          "g",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "r",
+          "s"
+        ]
+      },
+      {
+        "marc": "730",
+        "subfields": [
+          "a",
+          "d",
+          "f",
+          "g",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "r",
+          "s",
+          "t"
+        ]
+      },
+      {
+        "marc": "830",
+        "subfields": [
+          "a",
+          "d",
+          "f",
+          "g",
+          "k",
+          "l",
+          "m",
+          "n",
+          "o",
+          "p",
+          "r",
+          "s",
+          "t",
+          "v"
+        ]
+      }
+    ]
+  },
+  "titleDisplay": {
+    "paths": [
+      {
+        "marc": "245",
+        "subfields": [
+          "a",
+          "b",
+          "c",
+          "f",
+          "g",
+          "h",
+          "k",
+          "n",
+          "p",
+          "s"
+        ]
+      }
+    ]
+  },
+  "hasReproduction": {
+    "paths": [
+      {
+        "marc": "533",
+        "description": "Reproduction Note"
+      }
+    ]
+  },
+  "reproductionOf": {
+    "paths": [
+      {
+        "marc": "534",
+        "description": "Original Version Note",
+        "nyplSources": [
+          "*"
         ]
       }
     ]

--- a/lib/mappings/holding-mapping.json
+++ b/lib/mappings/holding-mapping.json
@@ -1,1 +1,129 @@
-{}
+{
+  "identifier": {},
+  "callNumber": {
+    "paths": [
+      {
+        "marc": "852",
+        "subfields": [
+          "k",
+          "h",
+          "i",
+          "n",
+          "z"
+        ]
+      }
+    ]
+  },
+  "physicalLocation": {
+    "paths": [
+      {
+        "marc": "852",
+        "subfields": [
+          "k",
+          "h",
+          "i"
+        ]
+      }
+    ]
+  },
+  "enumerationChronology": {
+    "paths": [
+      {
+        "notes": "Drawn from 'v' legacy field"
+      }
+    ]
+  },
+  "holdingStatement": {
+    "paths": [
+      {
+        "marc": "866",
+        "subfields": [
+          "h"
+        ]
+      },
+      {
+        "marc": "853",
+        "subfields": [
+          "8",
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "f",
+          "i",
+          "j",
+          "k",
+          "l"
+        ],
+        "notes": "Provides structure for metadata in 863 fields"
+      },
+      {
+        "marc": "863",
+        "subfields": [
+          "8",
+          "a",
+          "b",
+          "c",
+          "d",
+          "e",
+          "f",
+          "i",
+          "j",
+          "k",
+          "l"
+        ],
+        "notes": "Provides structured data as defined in 853 fields"
+      },
+      {
+        "notes": "Additional data drawn from the fieldTag 'h' fields"
+      },
+      {
+        "notes": "Pre-formatted statements also available in holdings.holding_statement field"
+      }
+    ]
+  },
+  "location": {
+    "paths": [
+      {
+        "marc": "Location",
+        "notes": "derived from location code stored in record"
+      }
+    ]
+  },
+  "format": {
+    "paths": [
+      {
+        "marc": "843",
+        "subfields": [
+          "a"
+        ],
+        "notes": "With 843 present, fieldTag may be i or n"
+      },
+      {
+        "notes": "Drawn from fieldTag 'i'"
+      }
+    ]
+  },
+  "note": {
+    "paths": [
+      {
+        "notes": "Drawn from fieldTag 'n', but not if marc field is 843"
+      }
+    ]
+  },
+  "checkInBox": {
+    "paths": [
+      {
+        "notes": "Drawn from enumeration, start_date and end_date fields"
+      }
+    ]
+  },
+  "suppressed": {
+    "paths": [
+      {
+        "notes": "set true if deleted or suppressed fields are set to true"
+      }
+    ]
+  }
+}

--- a/lib/mappings/item-mapping.json
+++ b/lib/mappings/item-mapping.json
@@ -1,1 +1,160 @@
-{}
+{
+  "accessMessage": {
+    "paths": [
+      {
+        "marc": "fixedFields.108.value",
+        "nyplSources": [
+          "*"
+        ]
+      }
+    ]
+  },
+  "aeonSiteCode": {
+    "paths": [
+      {
+        "notes": "fieldTag x matching /^AEON eligible/"
+      }
+    ]
+  },
+  "availability": {
+    "paths": [
+      {
+        "marc": "status",
+        "nyplSources": [
+          "*"
+        ]
+      }
+    ]
+  },
+  "barcode": {
+    "paths": [
+      {
+        "marc": "barcode"
+      }
+    ]
+  },
+  "callNumber": {
+    "paths": [
+      {
+        "marc": "852",
+        "subfields": [
+          "k",
+          "h",
+          "i"
+        ],
+        "notes": "Join 852 $k $h $i fields and fieldTag 'v' value (if available) with a space"
+      },
+      {
+        "marc": "945",
+        "subfields": [
+          "g"
+        ]
+      }
+    ]
+  },
+  "carrierType": {
+    "paths": [
+      {
+        "notes": "Based on item type"
+      }
+    ]
+  },
+  "catalogItemType": {
+    "paths": [
+      {
+        "marc": "fixedFields.61.value",
+        "nyplSources": [
+          "*"
+        ]
+      }
+    ]
+  },
+  "contentOwner": {
+    "paths": [
+      {
+        "marc": "location"
+      }
+    ]
+  },
+  "deliveryLocation": {
+    "paths": [
+      {
+        "notes": "based on application/mapping logic at https://docs.google.com/spreadsheets/d/1SwZyCSUMsQ0Lf91t39_LxKpSLbvNNEliOhF1bnyUwcA/edit?gid=940035354#gid=1104339016"
+      }
+    ]
+  },
+  "dueDate": {
+    "paths": [
+      {
+        "notes": "Use item.status.dueDate, stripped of time"
+      }
+    ]
+  },
+  "enumerationChronology": {
+    "paths": [
+      {
+        "notes": "Standalone representation of the 'v' fieldTag"
+      }
+    ]
+  },
+  "format": {},
+  "formatLiteral": {},
+  "holdingLocation": {
+    "paths": [
+      {
+        "marc": "location.code"
+      },
+      {
+        "marc": "852",
+        "subfields": [
+          "b"
+        ]
+      }
+    ]
+  },
+  "identifier": {},
+  "label": {},
+  "mediaType": {
+    "paths": [
+      {
+        "notes": "Based on item type"
+      }
+    ]
+  },
+  "physicalLocation": {
+    "paths": [
+      {
+        "marc": "852",
+        "subfields": [
+          "k",
+          "h",
+          "i"
+        ]
+      }
+    ]
+  },
+  "requestable": {
+    "paths": [
+      {
+        "notes": "based on application/mapping logic at https://docs.google.com/spreadsheets/d/1SwZyCSUMsQ0Lf91t39_LxKpSLbvNNEliOhF1bnyUwcA/edit?gid=940035354#gid=1104339016"
+      }
+    ]
+  },
+  "recapCustomerCode": {
+    "paths": [
+      {
+        "marc": "900",
+        "subfields": [
+          "b"
+        ]
+      }
+    ]
+  },
+  "suppressed": {
+    "paths": [
+      {
+        "notes": "suppressed or if location.code ends in 9. if bib's suppressed value is true, then item is suppressed"
+      }
+    ]
+  }
+}

--- a/lib/mappings/mappings.js
+++ b/lib/mappings/mappings.js
@@ -12,10 +12,9 @@ const amendMappingsBasedOnNyplSource = (data, nyplSource) => {
     const revised = Object.assign({}, data[name])
     if (revised.paths) {
       // Remove unmatching paths:
-      revised.paths = revised.paths.reduce((a, p) => {
-        if (!p.nyplSources || (Array.isArray(p.nyplSources) && sourceMatches(nyplSource, p.nyplSources))) a.push(p)
-        return a
-      }, [])
+      revised.paths = revised.paths.filter((path) => {
+        return (!path.nyplSources || (Array.isArray(path.nyplSources) && sourceMatches(nyplSource, path.nyplSources)))
+      })
     }
     m[name] = revised
     return m
@@ -33,6 +32,8 @@ const makeMappingsGetter = (type, nyplSource) => {
 }
 
 module.exports = {
+  sourceMatches,
+  amendMappingsBasedOnNyplSource,
   BibMappings: {
     get: makeMappingsGetter('bib')
   },

--- a/test/mappings.test.js
+++ b/test/mappings.test.js
@@ -1,0 +1,165 @@
+const expect = require('chai').expect
+
+const {
+  sourceMatches,
+  amendMappingsBasedOnNyplSource,
+  BibMappings,
+  ItemMappings,
+  HoldingMappings
+} = require('../lib/mappings/mappings')
+
+describe('mappings', function () {
+  describe('amendMappingsBasedOnNyplSource', function () {
+    it('should filter out paths with non-matching nypl sources', function () {
+      const data = {
+        title: {
+          paths: [
+            {
+              marc: '245',
+              subfields: [
+                'a',
+                'b'
+              ],
+              nyplSources: [
+                'sierra-nypl',
+                'recap-cul',
+                'recap-pul'
+              ]
+            },
+            {
+              marc: '245',
+              subfields: [
+                'a',
+                'b',
+                'c'
+              ],
+              nyplSources: [
+                'recap-hl'
+              ]
+            }
+          ]
+        },
+        type: {
+          paths: [
+            {
+              marc: 'LDR/07'
+            }
+          ]
+        }
+      }
+      const nyplSource = 'sierra-nypl'
+      const expectedAmendedData = {
+        title: {
+          paths: [
+            {
+              marc: '245',
+              subfields: [
+                'a',
+                'b'
+              ],
+              nyplSources: [
+                'sierra-nypl',
+                'recap-cul',
+                'recap-pul'
+              ]
+            }
+          ]
+        },
+        type: {
+          paths: [
+            {
+              marc: 'LDR/07'
+            }
+          ]
+        }
+      }
+      expect(amendMappingsBasedOnNyplSource(data, nyplSource)).to.deep.equal(expectedAmendedData)
+    })
+  })
+
+  describe('sourceMatches', function () {
+    it('should return true if any of the patterns are equal to the given source', function () {
+      expect(sourceMatches('sierra-nypl', ['recap-pul', 'sierra-nypl'])).to.equal(true)
+    })
+
+    it('should return true if any of the patterns is *', function () {
+      expect(sourceMatches('sierra-nypl', ['recap-pul', '*'])).to.equal(true)
+    })
+
+    it('should return false if there are no matching patterns', function () {
+      expect(sourceMatches('sierra-nypl', ['recap-pul', 'recap-cul'])).to.equal(false)
+    })
+  })
+
+  describe('model mappers', function () {
+    describe('BibMappings', function () {
+      it('should have a get function that extracts from bib mappings', function () {
+        expect(BibMappings.get('title', {})).to.deep.equal(
+          {
+            paths: [
+              {
+                marc: '245',
+                subfields: [
+                  'a',
+                  'b'
+                ],
+                nyplSources: [
+                  'sierra-nypl',
+                  'recap-cul',
+                  'recap-pul'
+                ]
+              },
+              {
+                marc: '245',
+                subfields: [
+                  'a',
+                  'b',
+                  'c'
+                ],
+                nyplSources: [
+                  'recap-hl'
+                ]
+              }
+            ]
+          }
+        )
+      })
+    })
+
+    describe('ItemMappings', function () {
+      it('should have a get function that extracts from item mappings', function () {
+        expect(ItemMappings.get('recapCustomerCode', {})).to.deep.equal(
+          {
+            paths: [
+              {
+                marc: '900',
+                subfields: [
+                  'b'
+                ]
+              }
+            ]
+          }
+        )
+      })
+    })
+
+    describe('HoldingMappings', function () {
+      it('should have a get function that extracts from holding mappings', function () {
+        expect(HoldingMappings.get('physicalLocation', {})).to.deep.equal(
+          {
+            paths: [
+              {
+                marc: '852',
+                subfields: [
+                  'k',
+                  'h',
+                  'i'
+                ]
+              }
+            ]
+          }
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Supplements scc-3260 with expanded bib/item/holdings mappings files
- Adds tests for mappings methods
- Some minor simplifications of mappings methods