### PR TITLE
Refactoring and fixing orphaned parallel extraction

### DIFF
--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -46,7 +46,7 @@ class SierraBase {
   // This function takes a marc tag, and returns an array of primary values with
   //   relevant parallel values attached and or orphaned parallels relevant to
   //   given marc tag
-  _addParallels (marc) {
+  _fieldsWithParallelsAndOrPrimaries (marc) {
     // _varFieldByMarcTag returns array of raw marc fields filtered by marc tag:
     //  [{fieldTag: 'a', marcTag: '123', content: 'the thing'}]
     const primaryRawFields = this._varFieldByMarcTag(marc)
@@ -64,7 +64,7 @@ class SierraBase {
       return { ...lookup, [number]: rawField }
     }, {})
 
-    const lookup = (field) => {
+    const attachParallelToPrimary = (field) => {
       const subfieldSix = this._parseSubfield6(field)
       if (subfieldSix) {
         const { number: subfieldSixSuffix } = subfieldSix
@@ -73,25 +73,19 @@ class SierraBase {
           //    add parallel to the primary
           field.parallel = { ...parallelsLookup[subfieldSixSuffix] }
           //    set value to null, so we know that parallel has been matched
-          parallelsLookup[subfieldSixSuffix] = null
+          delete parallelsLookup[subfieldSixSuffix]
         }
       }
+      return field
     }
 
-    const primariesWithAndWithoutMatches = primaryRawFields.map((field, i) => {
-      // attach relevant parallels
-      lookup(field)
-      return field
-    })
+    const primariesWithAndWithoutMatches = primaryRawFields
+      .map(attachParallelToPrimary)
 
-    const orphanParallels = parallelRawFields.map((field) => {
-      // check if parallel remains unmatched in lookup table.
-      //   if it is, it will be returned {parallel: {value:'meep', subfieldMap: {'a': 'meep'}}}
-      lookup(field)
-      if (field.parallel) {
-        return field
-      } else { return null }
-    }).filter((p) => p)
+    const orphanParallels = Object.values(parallelsLookup)
+      .map((parallel) => ({ parallel }))
+
+    // Join primaries (with attached parallels) to orphaned parallels
     return primariesWithAndWithoutMatches.concat(orphanParallels)
   }
 
@@ -106,7 +100,8 @@ class SierraBase {
     // prettifyRawVarFields returns array with massaged values per subfield
     //  [{value: 'subfields concatenated', subfieldMap: { a: 'subfields', b: 'concatenated'}}]
     //  for 880 marcTag fields, you end up with the full parallel link and the subfield map
-    const fieldsWithParallelsAndOrPrimaries = this._addParallels(marc)
+
+    const fieldsWithParallelsAndOrPrimaries = this._fieldsWithParallelsAndOrPrimaries(marc)
     // do extraction here after everything is all matched
     const fieldsFormatted = this._prettifyRawVarFields(fieldsWithParallelsAndOrPrimaries, subfields, opts)
     return fieldsFormatted
@@ -136,7 +131,7 @@ class SierraBase {
 
   // returns array of objects. value is concatenation of contents of
   //   specified subfields - {value: 'val parallel link', subfieldMap: {a:'val', 6:'parallel link'}}
-  _prettifyRawVarFields (rawFields, subfields, opts) {
+  _prettifyRawVarFields (rawFields, whichSubfields, opts) {
     opts = opts || {}
     opts = Object.assign({
       tagSubfields: false,
@@ -147,42 +142,47 @@ class SierraBase {
 
     if (Array.isArray(rawFields) && rawFields.length) {
       const vals = rawFields.filter(opts.preFilter).map((field) => {
-        if (field.parallel) {
-          const subfield6 = this._parseSubfield6(field.parallel)
-          // coerce parallel into array for the purpose of recursive call
-          field.parallel = this._prettifyRawVarFields([field.parallel], subfields, opts)[0]
-          if (subfield6) {
-            field.parallel.script = subfield6.script
-            field.parallel.direction = subfield6.direction
-          }
-        }
-        // sometimes there's a case error...
-        const unfilteredFields = field.subFields || field.subfields
-        // Remove any subfield we're meant to exclude, including subfield 6
-        const _subFields = unfilteredFields && opts.excludedSubfields
-          ? unfilteredFields.filter(subfield => {
-            return !opts.excludedSubfields.includes(subfield.tag) && subfield.tag !== '6'
-          })
-          : unfilteredFields
+        // Build return:
+        const varFieldMatchReturn = {}
 
-        const subfieldParse = (subs) => {
-          const subfieldMap = subs.reduce((hash, sub) => {
+        // Build value
+        //
+        // If this raw varfield contains any subfields at all (always true, except for orphaned parallels):
+        // (sometimes there's a case error)
+        const unfilteredSubFields = field.subFields || field.subfields
+        if (unfilteredSubFields) {
+          let filteredSubfields = unfilteredSubFields
+
+          // Apply inclusion/exclusion rules to select desired subfields:
+          if (whichSubfields) {
+            filteredSubfields = filteredSubfields
+              .filter((sub) => whichSubfields.indexOf(sub.tag) >= 0)
+          } else if (opts.excludedSubfields) {
+            filteredSubfields = filteredSubfields
+              .filter((sub) => !opts.excludedSubfields.includes(sub.tag) && sub.tag !== '6')
+          }
+
+          varFieldMatchReturn.value = filteredSubfields.map((sub) => sub.content).join(opts.subfieldJoiner)
+          varFieldMatchReturn.subfieldMap = filteredSubfields.reduce((hash, sub) => {
             hash[sub.tag] = sub.content
             return hash
           }, {})
-          const value = subs.map((sub) => sub.content).join(opts.subfieldJoiner)
-          if (field.parallel) return { value, subfieldMap, parallel: field.parallel }
-          else return { value, subfieldMap }
+        } else if (field.content) {
+          varFieldMatchReturn.value = field.content
         }
 
-        // If asked to match certain subfields, return only those:
-        if (subfields) {
-          const subs = (_subFields || []).filter((sub) => subfields.indexOf(sub.tag) >= 0)
-          return subfieldParse(subs)
-          // Otherwise, attempt to return 'content', falling back on subfields' content:
-        } else {
-          return field.content || (_subFields ? subfieldParse(_subFields) : null)
+        // Build parallel:
+        if (field.parallel) {
+          const subfield6 = this._parseSubfield6(field.parallel)
+          // coerce parallel into array for the purpose of recursive call
+          varFieldMatchReturn.parallel = this._prettifyRawVarFields([field.parallel], whichSubfields, opts)[0]
+          if (subfield6) {
+            varFieldMatchReturn.parallel.script = subfield6.script
+            varFieldMatchReturn.parallel.direction = subfield6.direction
+          }
         }
+
+        return varFieldMatchReturn
       })
       return [].concat.apply([], vals).filter((v) => v)
     } else return []

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -21,7 +21,7 @@ class SierraBase {
 
   fieldTag (field, subfields, opts) {
     const varFields = this._varFieldByFieldTag(field)
-    return this._prettifyRawVarFields(varFields, subfields, opts)
+    return this._convertRawFieldToVarFieldMatch(varFields, subfields, opts)
   }
 
   _cacheParallels () {
@@ -103,7 +103,7 @@ class SierraBase {
 
     const fieldsWithParallelsAndOrPrimaries = this._fieldsWithParallelsAndOrPrimaries(marc)
     // do extraction here after everything is all matched
-    const fieldsFormatted = this._prettifyRawVarFields(fieldsWithParallelsAndOrPrimaries, subfields, opts)
+    const fieldsFormatted = this._convertRawFieldToVarFieldMatch(fieldsWithParallelsAndOrPrimaries, subfields, opts)
     return fieldsFormatted
   }
 
@@ -131,7 +131,7 @@ class SierraBase {
 
   // returns array of objects. value is concatenation of contents of
   //   specified subfields - {value: 'val parallel link', subfieldMap: {a:'val', 6:'parallel link'}}
-  _prettifyRawVarFields (rawFields, whichSubfields, opts) {
+  _convertRawFieldToVarFieldMatch (rawFields, includedSubfields, opts) {
     opts = opts || {}
     opts = Object.assign({
       tagSubfields: false,
@@ -154,9 +154,9 @@ class SierraBase {
           let filteredSubfields = unfilteredSubFields
 
           // Apply inclusion/exclusion rules to select desired subfields:
-          if (whichSubfields) {
+          if (includedSubfields) {
             filteredSubfields = filteredSubfields
-              .filter((sub) => whichSubfields.indexOf(sub.tag) >= 0)
+              .filter((sub) => includedSubfields.indexOf(sub.tag) >= 0)
           } else if (opts.excludedSubfields) {
             filteredSubfields = filteredSubfields
               .filter((sub) => !opts.excludedSubfields.includes(sub.tag) && sub.tag !== '6')
@@ -175,7 +175,7 @@ class SierraBase {
         if (field.parallel) {
           const subfield6 = this._parseSubfield6(field.parallel)
           // coerce parallel into array for the purpose of recursive call
-          varFieldMatchReturn.parallel = this._prettifyRawVarFields([field.parallel], whichSubfields, opts)[0]
+          varFieldMatchReturn.parallel = this._convertRawFieldToVarFieldMatch([field.parallel], includedSubfields, opts)[0]
           if (subfield6) {
             varFieldMatchReturn.parallel.script = subfield6.script
             varFieldMatchReturn.parallel.direction = subfield6.direction

--- a/test/fixtures/bib-parallels-chaos.json
+++ b/test/fixtures/bib-parallels-chaos.json
@@ -1,0 +1,196 @@
+{
+  "varFields": [
+    {
+      "fieldTag": "d",
+      "marcTag": "600",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-01"
+        },
+        {
+          "tag": "a",
+          "content": "600 primary value a"
+        },
+        {
+          "tag": "b",
+          "content": "600 primary value b"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "600-01/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "600 parallel value a"
+        },
+        {
+          "tag": "b",
+          "content": "600 parallel value b"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "100-01/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "100 parallel value a"
+        },
+        {
+          "tag": "b",
+          "content": "100 parallel value b"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "200-02/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "200 orphaned parallel value a"
+        },
+        {
+          "tag": "b",
+          "content": "200 orphaned parallel value b"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "200",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-03"
+        },
+        {
+          "tag": "a",
+          "content": "200 primary value a"
+        },
+        {
+          "tag": "b",
+          "content": "200 primary value b"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "200-03/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "200 parallel value a"
+        },
+        {
+          "tag": "b",
+          "content": "200 parallel value b"
+        }
+      ]
+    },
+
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "300-05/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "300 orphaned parallel value a"
+        },
+        {
+          "tag": "b",
+          "content": "300 orphaned parallel value b"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "300",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "880-04"
+        },
+        {
+          "tag": "a",
+          "content": "300 primary value a"
+        },
+        {
+          "tag": "b",
+          "content": "300 primary value b"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "880",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "6",
+          "content": "300-04/(3/r"
+        },
+        {
+          "tag": "a",
+          "content": "300 parallel value a"
+        },
+        {
+          "tag": "b",
+          "content": "300 parallel value b"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Some proposals to:
 - fix orphaned parallel extraction, which wasn't handled properly before (parallel values were taking the place of primary values)
 - refactor the "prettify" function for clarity
 - add tests to cover some contrived edge cases with orphaned parallels