### PR TITLE
Scc 3422/add m2 indexing

### DIFF
--- a/lib/platform-api/client.js
+++ b/lib/platform-api/client.js
@@ -8,7 +8,7 @@ let clientPromise = null
  * Initialize a Platform API client from encrypted creds found in process.env
  *
  */
-const instance = async () => {
+const client = async () => {
   // Create a Promise to decrypt creds and resolve a client:
   if (!clientPromise) {
     const [key, secret] = await Promise.all([
@@ -29,5 +29,5 @@ const instance = async () => {
 }
 
 module.exports = {
-  instance
+  client
 }

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -8,19 +8,18 @@ const { chunk } = require('lodash')
  *  Given an array of barcodes, resolves a map relating barcoes to M2 customer
  *  codes (if found).
  */
-const m2CustomerCodesForBarcodes = async (barcodes, offset = 0, map = {}) => {
+const m2CustomerCodesForBarcodes = async (barcodes, offset = 0, map = {}, batchSize = 200) => {
   if (!barcodes || barcodes.length === 0) return {}
-
   // Batch calls to the m2-customer-code-store in groups of 200 barcodes:
-  const batchSize = 200
-  const barcodesBatch = barcodes.slice(offset, offset + batchSize)
 
+  const barcodesBatch = barcodes.slice(offset, offset + batchSize)
   const client = await platformApi.client()
   const response = await client.get(`m2-customer-codes?barcodes=${barcodesBatch.join(',')}`)
 
   // Convert response to a map relating barcode to CC:
-  const responseAsMap = response.data
-    .reduce((h, result) => {
+  const responseAsMap = response.status !== 200
+    ? {}
+    : response.data.reduce((h, result) => {
       return Object.assign(h, { [result.barcode]: result.m2CustomerCode })
     }, {})
   // Merge this map with the map built from previous batched calls:
@@ -31,7 +30,7 @@ const m2CustomerCodesForBarcodes = async (barcodes, offset = 0, map = {}) => {
     return map
   } else {
     // There are more batches to fetch; recurse:
-    return m2CustomerCodesForBarcodes(barcodes, offset + batchSize, map)
+    return m2CustomerCodesForBarcodes(barcodes, offset + batchSize, map, batchSize)
   }
 }
 

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -17,7 +17,7 @@ const m2CustomerCodesForBarcodes = async (barcodes, offset = 0, map = {}, batchS
   const response = await client.get(`m2-customer-codes?barcodes=${barcodesBatch.join(',')}`)
 
   // Convert response to a map relating barcode to CC:
-  const responseAsMap = response.status !== 200
+  const responseAsMap = response.status === 400
     ? {}
     : response.data.reduce((h, result) => {
       return Object.assign(h, { [result.barcode]: result.m2CustomerCode })

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -3,9 +3,41 @@ const platformApi = require('./client')
 const { isValidResponse } = require('../utils')
 const { chunk } = require('lodash')
 
+/**
+ *
+ *  Given an array of barcodes, resolves a map relating barcoes to M2 customer
+ *  codes (if found).
+ */
+const m2CustomerCodesForBarcodes = async (barcodes, offset = 0, map = {}) => {
+  if (!barcodes || barcodes.length === 0) return {}
+
+  // Batch calls to the m2-customer-code-store in groups of 200 barcodes:
+  const batchSize = 200
+  const barcodesBatch = barcodes.slice(offset, offset + batchSize)
+
+  const client = await platformApi.client()
+  const response = await client.get(`m2-customer-codes?barcodes=${barcodesBatch.join(',')}`)
+
+  // Convert response to a map relating barcode to CC:
+  const responseAsMap = response.data
+    .reduce((h, result) => {
+      return Object.assign(h, { [result.barcode]: result.m2CustomerCode })
+    }, {})
+  // Merge this map with the map built from previous batched calls:
+  map = Object.assign(map, responseAsMap)
+
+  // If there are no more batches to fetch, return map
+  if (barcodes.length <= offset + batchSize) {
+    return map
+  } else {
+    // There are more batches to fetch; recurse:
+    return m2CustomerCodesForBarcodes(barcodes, offset + batchSize, map)
+  }
+}
+
 const getSchema = async (schemaName) => {
   try {
-    const client = await platformApi.instance()
+    const client = await platformApi.client()
     const path = `current-schemas/${schemaName}`
     const resp = await client.get(path, { authenticate: false })
     if (isValidResponse(resp)) {
@@ -20,7 +52,7 @@ const getSchema = async (schemaName) => {
 
 const bibById = async (nyplSource, id) => {
   try {
-    const client = await platformApi.instance()
+    const client = await platformApi.client()
     const resp = await client.get(`bibs/${nyplSource}/${id}`)
     if (isValidResponse(resp)) {
       return resp.data
@@ -42,7 +74,7 @@ const _itemsForOneBib = async (bib, offset = 0, limit = 500) => {
   try {
     const path = `bibs/${bib.nyplSource}/${bib.id}/items?limit=${limit}&offset=${offset}`
     logger.debug('PlatformApi#_itemsForOneBib: Fetch: ' + path)
-    const client = await platformApi.instance()
+    const client = await platformApi.client()
     const resp = await client.get(path)
     if (isValidResponse(resp)) {
       logger.debug(`PlatformApi#_itemsForOneBib: Got ${resp.data.length ? resp.data.length : 'no'} items`)
@@ -115,7 +147,7 @@ const _holdingsForBibs = async (bibs) => {
     const nyplBibs = bibs.filter((bib) => bib.nyplSource === 'sierra-nypl')
     const bibGroups = chunk(nyplBibs, 25)
     logger.debug('_holdingsForBibs: Fetching holdings for bibs in groups: ', bibGroups)
-    const client = await platformApi.instance()
+    const client = await platformApi.client()
     const holdings = await Promise.all(bibGroups.map(async (bibs) => {
       const path = `holdings?bib_ids=${bibs.map((bib) => bib.id).join(',')}`
       const resp = await client.get(path)
@@ -166,5 +198,6 @@ module.exports = {
   _holdingsForBibs,
   _bibIdentifiersForHoldings,
   _bibIdentifiersForItems,
-  bibsForHoldingsOrItems
+  bibsForHoldingsOrItems,
+  m2CustomerCodesForBarcodes
 }

--- a/lib/scsb/client.js
+++ b/lib/scsb/client.js
@@ -5,7 +5,7 @@ const scsbClient = require('@nypl/scsb-rest-client')
 let _clientPromise = null
 
 /**
- *  Get an SCSB client instance
+ *  Get an SCSB client client
  *
  *  @return {Promies<scsbclient>} - Returns a promise that resolves an authenticated client
  */

--- a/lib/utils/m2-customer-codes.js
+++ b/lib/utils/m2-customer-codes.js
@@ -1,0 +1,34 @@
+const platformApi = require('../platform-api/requests')
+
+/**
+ * Given a location code, returns true if the location is in M2
+ *
+ * Should match:
+ *   mal92, mal98, mal99, mag92, maf92, maf98, maf99, mas92, map92, map98
+ *
+ * Ideally this would be data-driven rather than hard coded, but at writing,
+ * NYPL-Core does not associate M2 customer codes with Sierra holding locations
+ * (only delivery locations)
+*/
+const isM2Location = (location) => /^(mal9|mag9|maf9|mas9|map9)/.test(location)
+
+const attachM2CustomerCodes = async (bib) => {
+  // Get barcodes from M2 items:
+  const barcodes = bib.items()
+    .filter((item) => item.barcode)
+    .filter((item) => item.location && isM2Location(item.location.code))
+    .map((item) => item.barcode)
+  // Get map relating barcodes to M2 Customer Codes:
+  const barcodeToM2CustomerCode = await platformApi.m2CustomerCodesForBarcodes(barcodes)
+  bib._items = bib.items().map((item) => {
+    if (barcodeToM2CustomerCode[item.barcode]) {
+      item.m2CustomerCode = barcodeToM2CustomerCode[item.barcode]
+    }
+    return item
+  })
+  return bib
+}
+
+module.exports = {
+  attachM2CustomerCodes
+}

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -71,18 +71,18 @@ describe('index handler function', () => {
     })
     it('instantiates bibs with items and holdings', () => {
       expect(bibs.filter((bib) => bib._items.length && bib._holdings.length).length).to.equal(10)
-      expect(bibs[0].items()[0]).to.be.instanceOf(SierraItem)
-      expect(bibs[0].holdings()[0]).to.be.instanceOf(SierraHolding)
+      expect(bibs[0].items()[0]).to.be.clientOf(SierraItem)
+      expect(bibs[0].holdings()[0]).to.be.clientOf(SierraHolding)
     })
     it('holdings are attached to bibs', () => {
       const bibOnHolding = bibs[0].holdings()[0].bibs()
       expect(bibOnHolding).to.have.length(1)
-      expect(bibOnHolding[0]).to.be.instanceOf(SierraBib)
+      expect(bibOnHolding[0]).to.be.clientOf(SierraBib)
     })
     it('items are attached to bibs', () => {
       const bibOnItem = bibs[0].items()[0].bibs()
       expect(bibOnItem).to.have.length(1)
-      expect(bibOnItem[0]).to.be.instanceOf(SierraBib)
+      expect(bibOnItem[0]).to.be.clientOf(SierraBib)
     })
   })
 

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -71,18 +71,18 @@ describe('index handler function', () => {
     })
     it('instantiates bibs with items and holdings', () => {
       expect(bibs.filter((bib) => bib._items.length && bib._holdings.length).length).to.equal(10)
-      expect(bibs[0].items()[0]).to.be.clientOf(SierraItem)
-      expect(bibs[0].holdings()[0]).to.be.clientOf(SierraHolding)
+      expect(bibs[0].items()[0]).to.be.instanceOf(SierraItem)
+      expect(bibs[0].holdings()[0]).to.be.instanceOf(SierraHolding)
     })
     it('holdings are attached to bibs', () => {
       const bibOnHolding = bibs[0].holdings()[0].bibs()
       expect(bibOnHolding).to.have.length(1)
-      expect(bibOnHolding[0]).to.be.clientOf(SierraBib)
+      expect(bibOnHolding[0]).to.be.instanceOf(SierraBib)
     })
     it('items are attached to bibs', () => {
       const bibOnItem = bibs[0].items()[0].bibs()
       expect(bibOnItem).to.have.length(1)
-      expect(bibOnItem[0]).to.be.clientOf(SierraBib)
+      expect(bibOnItem[0]).to.be.instanceOf(SierraBib)
     })
   })
 

--- a/test/unit/m2-customer-codes.test.js
+++ b/test/unit/m2-customer-codes.test.js
@@ -13,7 +13,7 @@ describe('attachM2CustomerCodes', () => {
   after(() => {
     platformApi.m2CustomerCodesForBarcodes.restore()
   })
-  it.only('attaches m2 codes', async () => {
+  it('attaches m2 codes', async () => {
     const bib = { items: () => [{ location: { code: 'mal9' }, barcode: '123' }, { location: { code: 'mal9' }, barcode: '456' }] }
     const bibWithM2Codes = await attachM2CustomerCodes(bib)
     expect(bibWithM2Codes._items.map(item => item.m2CustomerCode)).to.deep.equal(['XX', 'YY'])

--- a/test/unit/m2-customer-codes.test.js
+++ b/test/unit/m2-customer-codes.test.js
@@ -5,7 +5,10 @@ const { attachM2CustomerCodes } = require('../../lib/utils/m2-customer-codes')
 
 describe('attachM2CustomerCodes', () => {
   before(() => {
-    const m2CustomerCodesApiStub = () => ({ 123: 'XX', 456: 'YY' })
+    const m2CustomerCodesApiStub = (barcodes) => {
+      if (barcodes.length) return { 123: 'XX', 456: 'YY' }
+      else return {}
+    }
     // stub m2 service to return m2codes for barcodes
     sinon.stub(platformApi, 'm2CustomerCodesForBarcodes')
       .callsFake(m2CustomerCodesApiStub)
@@ -13,9 +16,14 @@ describe('attachM2CustomerCodes', () => {
   after(() => {
     platformApi.m2CustomerCodesForBarcodes.restore()
   })
-  it('attaches m2 codes', async () => {
+  it('attaches m2 codes with valid location codes', async () => {
     const bib = { items: () => [{ location: { code: 'mal9' }, barcode: '123' }, { location: { code: 'mal9' }, barcode: '456' }] }
     const bibWithM2Codes = await attachM2CustomerCodes(bib)
     expect(bibWithM2Codes._items.map(item => item.m2CustomerCode)).to.deep.equal(['XX', 'YY'])
+  })
+  it('does not attach m2 codes with invalid location codes', async () => {
+    const bib = { items: () => [{ location: { code: 'lol' }, barcode: '456' }, { location: { code: 'lol' }, barcode: '123' }] }
+    const bibWithoutM2Codes = await attachM2CustomerCodes(bib)
+    expect(bibWithoutM2Codes._items.filter(item => item.m2CustomerCode)).to.deep.equal([])
   })
 })

--- a/test/unit/m2-customer-codes.test.js
+++ b/test/unit/m2-customer-codes.test.js
@@ -1,0 +1,21 @@
+const expect = require('chai').expect
+const sinon = require('sinon')
+const platformApi = require('../../lib/platform-api/requests')
+const { attachM2CustomerCodes } = require('../../lib/utils/m2-customer-codes')
+
+describe('attachM2CustomerCodes', () => {
+  before(() => {
+    const m2CustomerCodesApiStub = () => ({ 123: 'XX', 456: 'YY' })
+    // stub m2 service to return m2codes for barcodes
+    sinon.stub(platformApi, 'm2CustomerCodesForBarcodes')
+      .callsFake(m2CustomerCodesApiStub)
+  })
+  after(() => {
+    platformApi.m2CustomerCodesForBarcodes.restore()
+  })
+  it.only('attaches m2 codes', async () => {
+    const bib = { items: () => [{ location: { code: 'mal9' }, barcode: '123' }, { location: { code: 'mal9' }, barcode: '456' }] }
+    const bibWithM2Codes = await attachM2CustomerCodes(bib)
+    expect(bibWithM2Codes._items.map(item => item.m2CustomerCode)).to.deep.equal(['XX', 'YY'])
+  })
+})

--- a/test/unit/platform-api-client.test.js
+++ b/test/unit/platform-api-client.test.js
@@ -1,17 +1,17 @@
 const { expect } = require('chai')
-const { instance } = require('../../lib/platform-api/client')
+const { client } = require('../../lib/platform-api/client')
 
 describe('platform api client', () => {
-  let client
+  let apiClient
   it('creates a client if there is not one', async () => {
-    client = await instance()
+    apiClient = await client()
     expect(client).to.be.an('object')
   })
   it('returns existing client', async () => {
     before(() => {
-      client = instance()
+      apiClient = client()
     })
-    const secondClient = await instance()
-    expect(secondClient).to.equal(client)
+    const secondClient = await client()
+    expect(secondClient).to.equal(apiClient)
   })
 })

--- a/test/unit/platform-api-client.test.js
+++ b/test/unit/platform-api-client.test.js
@@ -5,7 +5,7 @@ describe('platform api client', () => {
   let apiClient
   it('creates a client if there is not one', async () => {
     apiClient = await client()
-    expect(client).to.be.an('object')
+    expect(apiClient).to.be.an('object')
   })
   it('returns existing client', async () => {
     before(() => {

--- a/test/unit/platform-api-requests.test.js
+++ b/test/unit/platform-api-requests.test.js
@@ -15,9 +15,10 @@ describe('platform api methods', () => {
     nullGetStub.resetHistory()
   })
   describe('m2CustomerCodesForBarcodes', () => {
-    it('returns empty object with no barcodes', async () => [
-      await requests.m2CustomerCodesForBarcodes()
-    ])
+    it('returns empty object with no barcodes', async () => {
+      const codes = await requests.m2CustomerCodesForBarcodes()
+      expect(codes).to.deep.equal({})
+    })
     it('returns populated map when there are barcodes', async () => {
       const barcodeGetStub = () => ({ status: 200, data: [{ barcode: 123, m2CustomerCode: 'XX' }, { barcode: 456, m2CustomerCode: 'YY' }] })
       stubPlatformApiGetRequest(barcodeGetStub)

--- a/test/unit/to-json.test.js
+++ b/test/unit/to-json.test.js
@@ -16,7 +16,7 @@ class Model {
 describe('toJson', () => {
   const mod = new Model({ id: 2 })
   describe('_getAllMethods', () => {
-    it('returns methods of class instance', () => {
+    it('returns methods of class client', () => {
       expect(_getAllMethods(mod)).to.deep.equal([
         '_privateMethod',
         'publicMethod'

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -6,11 +6,11 @@ const genericGetStub = sinon.stub().resolves({ data: {} })
 const nullGetStub = sinon.stub().resolves({})
 const errorGetStub = sinon.stub().throws()
 // This is a convenience function for stubbing the platformApi.
-const stubPlatformApiclient = (get) => sinon.stub(platformApi, 'client').resolves({ get })
+const stubPlatformApiGetRequest = (get) => sinon.stub(platformApi, 'client').resolves({ get })
 
 module.exports = {
   genericGetStub,
   nullGetStub,
   errorGetStub,
-  stubPlatformApiclient
+  stubPlatformApiGetRequest
 }

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -4,11 +4,11 @@ const platformApi = require('../../lib/platform-api/client')
 const genericGetStub = sinon.stub().resolves({ data: {} })
 const nullGetStub = sinon.stub().resolves({})
 const errorGetStub = sinon.stub().throws()
-const stubPlatformApiInstance = (get) => sinon.stub(platformApi, 'instance').resolves({ get })
+const stubPlatformApiclient = (get) => sinon.stub(platformApi, 'client').resolves({ get })
 
 module.exports = {
   genericGetStub,
   nullGetStub,
   errorGetStub,
-  stubPlatformApiInstance
+  stubPlatformApiclient
 }

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,9 +1,11 @@
 const sinon = require('sinon')
 
 const platformApi = require('../../lib/platform-api/client')
+
 const genericGetStub = sinon.stub().resolves({ data: {} })
 const nullGetStub = sinon.stub().resolves({})
 const errorGetStub = sinon.stub().throws()
+// This is a convenience function for stubbing the platformApi.
 const stubPlatformApiclient = (get) => sinon.stub(platformApi, 'client').resolves({ get })
 
 module.exports = {


### PR DESCRIPTION
This PR incorporates m2 customer code lookups to the indexing process. Largely copied from Paul's work, with an addition for handling a response without a 200 code. @nonword you might want to include something like that in the DHI as well. I'm not sold that this implementation is the move, but there definitely has to be something checking for response.data because 404 responses do not have a data property.
Also tests!