### PR TITLE
A few small fixes to parallel/primary extraction:

### DIFF
--- a/lib/mappings/mappings.js
+++ b/lib/mappings/mappings.js
@@ -22,11 +22,12 @@ const amendMappingsBasedOnNyplSource = (data, nyplSource) => {
 }
 
 const makeMappingsGetter = (type, nyplSource) => {
-  let mappings = require(`./${type}-mapping.json`)
+  const mappings = require(`./${type}-mapping.json`)
   return (propertyName, record) => {
+    let mappingsForRecord = mappings
     // If nyplSource given, trim mappings to agree with it:
-    if (record.nyplSource) mappings = amendMappingsBasedOnNyplSource(mappings, record.nyplSource)
-    return mappings[propertyName].paths || []
+    if (record.nyplSource) mappingsForRecord = amendMappingsBasedOnNyplSource(mappings, record.nyplSource)
+    return mappingsForRecord[propertyName].paths || []
   }
 }
 

--- a/lib/utils/primary-and-parallel-values.js
+++ b/lib/utils/primary-and-parallel-values.js
@@ -1,5 +1,5 @@
 const primaryValues = (varFieldMatchObjects) => {
-  return varFieldMatchObjects.map((match) => match.value)
+  return varFieldMatchObjects.map((match) => match.value || '')
 }
 
 const parallelValues = (varFieldMatchObjects) => {

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -33,8 +33,7 @@ describe('EsBib', function () {
       const record = new SierraBib(require('../fixtures/bib-11606020.json'))
       const esBib = new EsBib(record)
       expect(esBib.title()).to.deep.equal(
-        ['880-02 Sefer Toldot Yeshu = The gospel according to the Jews, called Toldoth Jesu : the generations of Jesus, now first translated from the Hebrew.',
-          '880-02 Sefer Toldot Yeshu = The gospel according to the Jews, called Toldoth Jesu : the generations of Jesus, now first translated from the Hebrew.'
+        ['Sefer Toldot Yeshu = The gospel according to the Jews, called Toldoth Jesu : the generations of Jesus, now first translated from the Hebrew.'
         ]
       )
     })

--- a/test/unit/mappings.test.js
+++ b/test/unit/mappings.test.js
@@ -94,71 +94,59 @@ describe('mappings', function () {
   describe('model mappers', function () {
     describe('BibMappings', function () {
       it('should have a get function that extracts from bib mappings', function () {
-        expect(BibMappings.get('title', {})).to.deep.equal(
+        expect(BibMappings.get('title', {})).to.deep.equal([
           {
-            paths: [
-              {
-                marc: '245',
-                subfields: [
-                  'a',
-                  'b'
-                ],
-                nyplSources: [
-                  'sierra-nypl',
-                  'recap-cul',
-                  'recap-pul'
-                ]
-              },
-              {
-                marc: '245',
-                subfields: [
-                  'a',
-                  'b',
-                  'c'
-                ],
-                nyplSources: [
-                  'recap-hl'
-                ]
-              }
+            marc: '245',
+            subfields: [
+              'a',
+              'b'
+            ],
+            nyplSources: [
+              'sierra-nypl',
+              'recap-cul',
+              'recap-pul'
+            ]
+          },
+          {
+            marc: '245',
+            subfields: [
+              'a',
+              'b',
+              'c'
+            ],
+            nyplSources: [
+              'recap-hl'
             ]
           }
-        )
+        ])
       })
     })
 
     describe('ItemMappings', function () {
       it('should have a get function that extracts from item mappings', function () {
-        expect(ItemMappings.get('recapCustomerCode', {})).to.deep.equal(
+        expect(ItemMappings.get('recapCustomerCode', {})).to.deep.equal([
           {
-            paths: [
-              {
-                marc: '900',
-                subfields: [
-                  'b'
-                ]
-              }
+            marc: '900',
+            subfields: [
+              'b'
             ]
           }
-        )
+        ])
       })
     })
 
     describe('HoldingMappings', function () {
       it('should have a get function that extracts from holding mappings', function () {
-        expect(HoldingMappings.get('physicalLocation', {})).to.deep.equal(
+        expect(HoldingMappings.get('physicalLocation', {})).to.deep.equal([
           {
-            paths: [
-              {
-                marc: '852',
-                subfields: [
-                  'k',
-                  'h',
-                  'i'
-                ]
-              }
+            marc: '852',
+            subfields: [
+              'k',
+              'h',
+              'i'
             ]
           }
-        )
+        ])
       })
     })
   })

--- a/test/unit/primary-and-parallel-values.test.js
+++ b/test/unit/primary-and-parallel-values.test.js
@@ -10,14 +10,13 @@ describe('primary and parallel values', () => {
       const bib = new SierraBib(require('../fixtures/bib-11606020.json'))
       const mappings = BibMappings.get('title', bib)
       expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal(
-        ['880-02 Sefer Toldot Yeshu = The gospel according to the Jews, called Toldoth Jesu : the generations of Jesus, now first translated from the Hebrew.',
-          '880-02 Sefer Toldot Yeshu = The gospel according to the Jews, called Toldoth Jesu : the generations of Jesus, now first translated from the Hebrew.'
+        ['Sefer Toldot Yeshu = The gospel according to the Jews, called Toldoth Jesu : the generations of Jesus, now first translated from the Hebrew.'
         ]
       )
     })
   })
 
-  describe.only('parallelValues', () => {
+  describe('parallelValues', () => {
     let bib
     before(() => {
       bib = new SierraBib(require('../fixtures/bib-11606020.json'))
@@ -34,6 +33,39 @@ describe('primary and parallel values', () => {
       const mappings = BibMappings.get('contributorLiteral', bib)
       expect(parallelValues(bib.varFieldsMulti(mappings))).to.deep.equal([''])
     })
+
+    it('should navigate parallel chaos', () => {
+      bib = new SierraBib(require('../fixtures/bib-parallels-chaos.json'))
+      let mappings
+
+      // This bib has a single primary 600 with a linked parallel that is tagged RTL
+      mappings = BibMappings.get('subjectLiteral', bib)
+      expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal(['600 primary value a 600 primary value b'])
+      expect(parallelValues(bib.varFieldsMulti(mappings))).to.deep.equal(['\u200F600 parallel value a 600 parallel value b'])
+
+      // This bib has a single 600 with a linked parallel that is tagged RTL
+      mappings = BibMappings.get('creatorLiteral', bib)
+      expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal([''])
+      expect(parallelValues(bib.varFieldsMulti(mappings))).to.deep.equal(['\u200F100 parallel value a 100 parallel value b'])
+
+      // This bib has a single primary 200 with a linked parallel and one orphaned parallel:
+      mappings = [{ marc: '200', subfields: ['a', 'b'] }]
+      expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal([
+        '200 primary value a 200 primary value b',
+        ''
+      ])
+      // Note that we're ordering the orphaned parallel last even though its $u
+      // has a subfield 6 number ('02') that is less than the non-orphaned
+      // parallel's subfield 6 number ('03'). Ideeally we would present lower-
+      // number values before higher value numbers, but orphaned parallels are
+      // rare enough that just including their value at the end of the array is
+      // sufficient for now.
+      expect(parallelValues(bib.varFieldsMulti(mappings))).to.deep.equal([
+        '\u200F200 parallel value a 200 parallel value b',
+        '\u200F200 orphaned parallel value a 200 orphaned parallel value b'
+      ])
+    })
+
     it('should append \'\u200F\' to parallel.value if direction is rtl', () => {
     })
   })

--- a/test/unit/primary-and-parallel-values.test.js
+++ b/test/unit/primary-and-parallel-values.test.js
@@ -43,7 +43,7 @@ describe('primary and parallel values', () => {
       expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal(['600 primary value a 600 primary value b'])
       expect(parallelValues(bib.varFieldsMulti(mappings))).to.deep.equal(['\u200F600 parallel value a 600 parallel value b'])
 
-      // This bib has a single 600 with a linked parallel that is tagged RTL
+      // This bib has a single orphaned parallel for marc 100 that is tagged RTL
       mappings = BibMappings.get('creatorLiteral', bib)
       expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal([''])
       expect(parallelValues(bib.varFieldsMulti(mappings))).to.deep.equal(['\u200F100 parallel value a 100 parallel value b'])


### PR DESCRIPTION
 - When `*Mappings.get` is called with a bib, the `mappings` lookup should not be modified for subsequent calls
 - Ensure missing primary values are rendered as ''
 - `*Mappings.get` methods should return an array of marc queries