### PR TITLE
SCC-3580: Fix a few small indexing issues

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -18,26 +18,6 @@ class EsBib extends EsBase {
     this.nyplSourceMapper = new NyplSourceMapper()
   }
 
-  async uri () {
-    const prefix = await this.nyplSourceMapper.prefix(this.nyplSource())
-    return `${prefix}${this.bib.id}`
-  }
-
-  _isAeonUrl (url) {
-    const aeonLinks = [
-      'https://specialcollections.nypl.org/aeon/Aeon.dll',
-      'https://nypl-aeon-test.aeon.atlas-sys.com'
-    ]
-    return Boolean(aeonLinks.some((path) => url.startsWith(path)))
-  }
-
-  _aeonUrls () {
-    const urls = this._extractElectronicResourcesFromBibMarc('complete digital record')
-      ?.map(({ url }) => url)
-      .filter(this._isAeonUrl)
-    return urls?.length ? urls : null
-  }
-
   carrierType () {
     // construct a suitable return object for the given fallback carriertype:
     const useDefault = function (id) {
@@ -112,6 +92,22 @@ class EsBib extends EsBase {
     return this._valueToIndexFromBasicMapping('contentsTitle')
   }
 
+  contributorLiteral () {
+    return this._valueToIndexFromBasicMapping('contributorLiteral')
+  }
+
+  contributor_sort () {
+    return this._sortify('contributorLiteral')
+  }
+
+  createdString () {
+    if (this._dateCreatedString()) return [this._dateCreatedString()]
+  }
+
+  createdYear () {
+    if (this._dateCreatedString()) return [parseInt(this._dateCreatedString())]
+  }
+
   creatorLiteral () {
     return this._valueToIndexFromBasicMapping('creatorLiteral')
   }
@@ -120,89 +116,22 @@ class EsBib extends EsBase {
     return this._sortify('creatorLiteral')
   }
 
-  parallelCreatorLiteral () {
-    return this._valueToIndexFromBasicMapping('creatorLiteral', false)
+  dateEndString () {
+    return [this.bib.varFieldSegment('008', [11, 14])]
   }
 
-  contributor_sort () {
-    return this._sortify('contributorLiteral')
+  dateEndYear () {
+    // TODO: Handle '9999', etc
+    return this.dateEndString()
+      .map((date) => parseInt(date))
   }
 
   dateStartYear () {
-    if (this._dateCreated()) return [this._dateCreated()]
+    if (this._dateCreatedString()) return [parseInt(this._dateCreatedString())]
   }
 
-  createdYear () {
-    if (this._dateCreated()) return [this._dateCreated()]
-  }
-
-  _dateCreated () {
-    if (this.bib.publishYear) return this.bib.publishYear
-    const dateBy008 = parseInt(this.bib.varFieldSegment('008', [7, 10]))
-    if (dateBy008) return dateBy008
-  }
-
-  // Returns array of hashes with { url, label }, containing electronic resources that are complete digital records
-  electronicResources () {
-    const resources = this._extractElectronicResourcesFromBibMarc('complete digital record')
-    return resources?.filter((resource) => !this._isAeonUrl(resource.url)) || null
-  }
-
-  /**
- * Given a MiJ bib and a e-resource type, returns extracted resources
- *
- * @param {object} bib Instance of BibSierraRecord
- * @param {string} type Type of resource to extract - either 'supplementary content' or 'complete digital record'
- *
- * @return {array} Array of objects representing electronic resources with following properties:
- * - url: URL of resoruce
- * - label: Label for resource if found
- * - path: "Path" to value in marc (for recording provo)
- */
-  _extractElectronicResourcesFromBibMarc (type) {
-    // Set up a filter to apply to 856 fields
-    // Unless `type` set to ER or Appendix, our preFilter accepts all e-resources:
-    let preFilter = () => true
-    // Each 856 entry with ind2 of '0' or '1' is a Electronic Resource:
-    if (type === 'complete digital record') preFilter = (marcBlock) => ['0', '1'].indexOf(String(marcBlock.ind2)) >= 0
-    // Each 856 entry with ind2 of '2' (or blank/unset) is "Appendix" (bib.supplementaryContent):
-    if (type === 'supplementary content') preFilter = (marcBlock) => !marcBlock.ind2 || String(marcBlock.ind2).trim() === '' || ['2'].indexOf(String(marcBlock.ind2)) >= 0
-
-    // URLs and labels can be anywhere, so pass `null` subfields param to get them all
-    const electronicStuff = this.bib.varField(856, null, { tagSubfields: true, preFilter })
-
-    if (electronicStuff && electronicStuff.length > 0) {
-      return electronicStuff.map(({ subfieldMap }) => {
-        // Consider all subfield values:
-        const values = Object.values(subfieldMap).filter((content) => content)
-        // // varFields automatically concatenates subfields into one string, but we want to ignore that
-        // delete values.value
-        // Get the one that looks like a URL
-        const isUrl = (v) => /^https?:/.test(v)
-        const url = values.filter(isUrl)[0]
-        // .. and choose the label from the longest value that isn't a URL
-        const label = values.filter((v) => !isUrl(v)).sort((e1, e2) => e1.length > e2.length ? -1 : 1)[0]
-
-        return url ? { url, label } : null
-      }).filter((r) => r)
-    } else return null
-  }
-
-  // _this parameter exists for testing
-  _sortify (func, _this = this) {
-    let literal = _this[func]()
-    if (!literal) return null
-    literal = Array.isArray(literal) ? literal[0] : literal
-    if (typeof literal !== 'string') return null
-    return [literal.substring(0, 80).toLowerCase()]
-  }
-
-  contributorLiteral () {
-    return this._valueToIndexFromBasicMapping('contributorLiteral')
-  }
-
-  serialPublicationDates () {
-    return this._valueToIndexFromBasicMapping('serialPublicationDates')
+  dateString () {
+    if (this._dateCreatedString()) return [this._dateCreatedString()]
   }
 
   description () {
@@ -215,6 +144,12 @@ class EsBib extends EsBase {
 
   donor () {
     return this._valueToIndexFromBasicMapping('donorSponsor')
+  }
+
+  // Returns array of hashes with { url, label }, containing electronic resources that are complete digital records
+  electronicResources () {
+    const resources = this._extractElectronicResourcesFromBibMarc('complete digital record')
+    return resources?.filter((resource) => !this._isAeonUrl(resource.url)) || null
   }
 
   extent () {
@@ -231,105 +166,7 @@ class EsBib extends EsBase {
 
   holdings () {
     return this.bib.holdings()
-      .map(h => new EsHolding(h))
-  }
-
-  items () {
-    return this.bib.items()
-      .map(item => new EsItem(item, this))
-      .concat(
-        this.bib.holdings()
-          .map(h => EsCheckinCardItem.fromSierraHolding(h))
-          .reduce((acc, el) => acc.concat(el), [])
-      )
-  }
-
-  _identifiers () {
-    let identifiers = []
-
-    // Add Bnumber as an identifier:
-    identifiers.push(
-      { value: this.bib.id, type: 'nypl:Bnumber' }
-    )
-
-    // Add ISBN(s):
-    if (this.idIsbn()) {
-      identifiers = identifiers.concat(
-        this.idIsbn().map((value) => ({ value, type: 'bf:Isbn' }))
-      )
-    }
-
-    // Add canceled/invalid ISBNs:
-    identifiers = identifiers.concat(
-      this.bib.varFieldsMulti(
-        BibMappings.get('isbnCanceledInvalid', this.bib)
-      ).map((value) => {
-        return { value, type: 'bf:Isbn', identifierStatus: 'canceled/invalid' }
-      })
-    )
-
-    // Add OCLC(s):
-    if (this.idOclc()) {
-      identifiers = identifiers.concat(
-        this.idOclc().map((value) => ({ value, type: 'nypl:Oclc' }))
-      )
-    }
-
-    // Add LCCN(s):
-    if (this.idLccn()) {
-      identifiers = identifiers.concat(
-        this.idLccn().map((value) => ({ value, type: 'nypl:Lccn' }))
-      )
-    }
-
-    // Add ISSN(s):
-    if (this.idIssn()) {
-      identifiers = identifiers.concat(
-        this.idIssn().map((value) => ({ value, type: 'nypl:Issn' }))
-      )
-    }
-
-    // Add canceled ISSNs:
-    identifiers = identifiers.concat(
-      this.bib.varFieldsMulti(
-        BibMappings.get('issnCanceled', this.bib)
-      ).map((value) => {
-        return { value, type: 'bf:Issn', identifierStatus: 'canceled' }
-      })
-    )
-
-    // Add incorrect ISSNs:
-    identifiers = identifiers.concat(
-      this.bib.varFieldsMulti(
-        BibMappings.get('issnIncorrect', this.bib)
-      ).map((value) => {
-        return { value, type: 'bf:Issn', identifierStatus: 'incorrect' }
-      })
-    )
-
-    // Add obscure system control numbers:
-    identifiers = identifiers.concat(
-      this.bib.varFieldsMulti(BibMappings.get('identifier', this.bib))
-        .filter((field) => {
-          // Filter out any of these identifiers that have already been added
-          // through more specific mappings above:
-          return !identifiers.some((otherIdentifier) => {
-            return otherIdentifier.id === field.value
-          })
-        })
-        .map((field) => {
-          return { value: field.value, type: 'bf:Identifier' }
-        })
-    )
-
-    // Add shelfmark (call number):
-    if (this.shelfMark()) {
-      identifiers = identifiers.concat(
-        this.shelfMark().map((value) => ({ value, type: 'bf:ShelfMark' }))
-      )
-    }
-
-    return identifiers
+      .map((h) => new EsHolding(h))
   }
 
   identifier () {
@@ -421,6 +258,32 @@ class EsBib extends EsBase {
     return pack(this.issuance())
   }
 
+  items () {
+    return this.bib.items()
+      .map(item => new EsItem(item, this))
+      .concat(
+        this.bib.holdings()
+          .map(h => EsCheckinCardItem.fromSierraHolding(h))
+          .reduce((acc, el) => acc.concat(el), [])
+      )
+  }
+
+  language () {
+    return this._languageCodes()
+      // Add lang label from lookup
+      .map((code) => {
+        const label = lookup('lookup-language-code-to-label')[code] || ''
+        return {
+          id: `lang:${code}`,
+          label
+        }
+      })
+  }
+
+  language_packed () {
+    return pack(this.language())
+  }
+
   lccClassification () {
     return this._valueToIndexFromBasicMapping('lccClassification')
   }
@@ -498,38 +361,10 @@ class EsBib extends EsBase {
     return pack(this.mediaType())
   }
 
-  /**
-   *  Returns a flat array of objects that have:
-   *   - varFieldMatchObject: A varfieldmatch having a primary, parallel, or both
-   *   - description: The note description (aka noteType)
-   */
-  _buildNotesArray () {
-    // noteType is description, type is bf:Note, label is the value
-    // get marctags
-    // const values = this._valueToIndexFromBasicMapping('note', primary)
-    const marcTags = BibMappings.get('note', this.bib)
-    return marcTags.map((path) => {
-      // example path:
-      // {
-      //   "marc": "501",
-      //   "subfields": [
-      //     "a"
-      //   ],
-      //   "description": "With"
-      // }
-      // contentPerMarcTag is an array of objects containing the content and subfieldMap
-      //    for the marc field and subfields supplied by the path.
-      const varFields = this.bib.varField(path.marc, path.subfields)
-      return varFields
-        .map((varFieldMatchObject) => ({ varFieldMatchObject, description: path.description }))
-      // remove empty arrays (no notes for a given marc tag)
-    }).filter((content) => {
-      return content.length
-    }).flat()
-  }
-
   note () {
     const notesArray = this._buildNotesArray()
+    if (!notesArray.length) return null
+
     // loop over the content so a separate object is generated for each one.
     return notesArray
       .map(({ varFieldMatchObject, description }, index) =>
@@ -543,33 +378,47 @@ class EsBib extends EsBase {
       )
   }
 
+  numCheckinCardItems () {
+    const count = this.items()
+      .filter((item) => item.type() && item.type().length && item.type()[0] === 'nypl:CheckinCardItem')
+      .length
+    return [count]
+  }
+
+  numItemDatesParsed () {
+    const count = this.items()
+      .filter((item) => item.dateRange())
+      .length
+    return [count]
+  }
+
   numElectronicResources () {
     return [this.electronicResources() ? this.electronicResources().length : 0]
   }
 
-  /**
-   * Returns an array of parallel note values rendered as parallelDisplayField
-   * entries
-   */
-  _parallelNotesAsDisplayFields () {
-    const notesArray = this._buildNotesArray()
-    return notesArray
-      // Convert the varfieldmatch objects into parallelDisplayField style
-      // objects:
-      .map(({ varFieldMatchObject, description }, index) => {
-        return {
-          value: parallelValue(varFieldMatchObject),
-          index,
-          fieldName: 'note'
-        }
-      })
-      // Now that we've assigned them index values, remove any that don't
-      // actually have any content:
-      .filter((parallelDisplayField) => parallelDisplayField.value)
+  numItemVolumesParsed () {
+    const ranges = this.items()
+      .map((item) => item.volumeRange())
+    const count = this.items()
+      .filter((item) => item.volumeRange())
+      .length
+    return [count]
+  }
+
+  numItemsTotal () {
+    return [this.items().length]
+  }
+
+  nyplSource () {
+    return this.bib.nyplSource ? [this.bib.nyplSource] : null
   }
 
   parallelContributorLiteral () {
     return this._valueToIndexFromBasicMapping('contributorLiteral', false)
+  }
+
+  parallelCreatorLiteral () {
+    return this._valueToIndexFromBasicMapping('creatorLiteral', false)
   }
 
   parallelDisplayField () {
@@ -615,6 +464,10 @@ class EsBib extends EsBase {
     return this._valueToIndexFromBasicMapping('subjectLiteral', false)
   }
 
+  parallelTitle () {
+    return this._valueToIndexFromBasicMapping('title', false)
+  }
+
   parallelUniformTitle () {
     return this._valueToIndexFromBasicMapping('uniformTitle', false)
   }
@@ -635,8 +488,22 @@ class EsBib extends EsBase {
     return this._valueToIndexFromBasicMapping('publisherLiteral')
   }
 
+  serialPublicationDates () {
+    return this._valueToIndexFromBasicMapping('serialPublicationDates')
+  }
+
   seriesStatement () {
     return this._valueToIndexFromBasicMapping('seriesStatement')
+  }
+
+  shelfMark () {
+    const callNumber = this._callNum()
+    if (callNumber && callNumber.value) {
+      // this fieldtag function will actually not add a fieldtagv the logic
+      //    returns nothing if there is a marc tag
+      const fieldTagV = this.bib.fieldTag('v')
+      if (fieldTagV) return [callNumber.value + fieldTagV]
+    }
   }
 
   subjectLiteral () {
@@ -654,11 +521,9 @@ class EsBib extends EsBase {
     } else return null
   }
 
-  _explode (string) {
-    const splitSubject = string.split('--')
-    return splitSubject.map((subject, i) => {
-      return splitSubject.slice(0, i + 1).join('--').trim()
-    })
+  // Returns array of hashes with { url, label }, containing electronic resources that are not complete digital records
+  supplementaryContent () {
+    return this._extractElectronicResourcesFromBibMarc('supplementary content') || null
   }
 
   tableOfContents () {
@@ -681,29 +546,6 @@ class EsBib extends EsBase {
     return this._valueToIndexFromBasicMapping('titleDisplay')
   }
 
-  _callNum () {
-    return getBibCallNum(this.bib)
-  }
-
-  shelfMark () {
-    const callNumber = this._callNum()
-    if (callNumber && callNumber.value) {
-      // this fieldtag function will actually not add a fieldtagv the logic
-      //    returns nothing if there is a marc tag
-      const fieldTagV = this.bib.fieldTag('v')
-      if (fieldTagV) return [callNumber.value + fieldTagV]
-    }
-  }
-
-  // Returns array of hashes with { url, label }, containing electronic resources that are not complete digital records
-  supplementaryContent () {
-    return this._extractElectronicResourcesFromBibMarc('supplementary content') || null
-  }
-
-  parallelTitle () {
-    return this._valueToIndexFromBasicMapping('title', false)
-  }
-
   type () {
     const issuance = this.issuance()
     if (issuance && ['collection', 'serial'].includes(issuance.label)) {
@@ -714,10 +556,6 @@ class EsBib extends EsBase {
     return ['nypl:Item']
   }
 
-  nyplSource () {
-    return this.bib.nyplSource ? [this.bib.nyplSource] : null
-  }
-
   uniformTitle () {
     return this._valueToIndexFromBasicMapping('uniformTitle')
   }
@@ -726,27 +564,50 @@ class EsBib extends EsBase {
     return Date.now()
   }
 
-  _languageCodes () {
-    let code = this.bib.varFieldSegment('008', [35, 37])
-    if (code) code = code.trim()
-    // Only accept 3-char lang codes:
-    if (code && code.length === 3) return [code]
-
-    return this.bib.varField('041', ['a'])
-      .map((match) => match.value.split(' '))
-      .reduce((acc, el) => acc.concat(el), [])
+  async uri () {
+    const prefix = await this.nyplSourceMapper.prefix(this.nyplSource())
+    return `${prefix}${this.bib.id}`
   }
 
-  language () {
-    return this._languageCodes()
-      // Add lang label from lookup
-      .map((code) => {
-        const label = lookup('lookup-language-code-to-label')[code] || ''
-        return {
-          id: `lang:${code}`,
-          label
-        }
-      })
+  _aeonUrls () {
+    const urls = this._extractElectronicResourcesFromBibMarc('complete digital record')
+      ?.map(({ url }) => url)
+      .filter(this._isAeonUrl)
+    return urls?.length ? urls : null
+  }
+
+  /**
+   *  Returns a flat array of objects that have:
+   *   - varFieldMatchObject: A varfieldmatch having a primary, parallel, or both
+   *   - description: The note description (aka noteType)
+   */
+  _buildNotesArray () {
+    // noteType is description, type is bf:Note, label is the value
+    // get marctags
+    // const values = this._valueToIndexFromBasicMapping('note', primary)
+    const marcTags = BibMappings.get('note', this.bib)
+    return marcTags.map((path) => {
+      // example path:
+      // {
+      //   "marc": "501",
+      //   "subfields": [
+      //     "a"
+      //   ],
+      //   "description": "With"
+      // }
+      // contentPerMarcTag is an array of objects containing the content and subfieldMap
+      //    for the marc field and subfields supplied by the path.
+      const varFields = this.bib.varField(path.marc, path.subfields)
+      return varFields
+        .map((varFieldMatchObject) => ({ varFieldMatchObject, description: path.description }))
+      // remove empty arrays (no notes for a given marc tag)
+    }).filter((content) => {
+      return content.length
+    }).flat()
+  }
+
+  _callNum () {
+    return getBibCallNum(this.bib)
   }
 
   _carrierTypeByVarField (useStrategies = ['338', '007']) {
@@ -767,6 +628,171 @@ class EsBib extends EsBase {
     }
   }
 
+  /**
+   *  Get date from bib.publishYear. Otherwise pull from 008.
+   *
+   *  In either case, we return the value as a string just in case it's not parsable as an int (e.g. "197-")
+   */
+  _dateCreatedString () {
+    if (this.bib.publishYear) return String(this.bib.publishYear)
+    const dateBy008 = this.bib.varFieldSegment('008', [7, 10])
+    if (dateBy008) return dateBy008
+  }
+
+  _explode (string) {
+    const splitSubject = string.split('--')
+    return splitSubject.map((subject, i) => {
+      return splitSubject.slice(0, i + 1).join('--').trim()
+    })
+  }
+
+  /**
+ * Given a MiJ bib and a e-resource type, returns extracted resources
+ *
+ * @param {object} bib Instance of BibSierraRecord
+ * @param {string} type Type of resource to extract - either 'supplementary content' or 'complete digital record'
+ *
+ * @return {array} Array of objects representing electronic resources with following properties:
+ * - url: URL of resoruce
+ * - label: Label for resource if found
+ * - path: "Path" to value in marc (for recording provo)
+ */
+  _extractElectronicResourcesFromBibMarc (type) {
+    // Set up a filter to apply to 856 fields
+    // Unless `type` set to ER or Appendix, our preFilter accepts all e-resources:
+    let preFilter = () => true
+    // Each 856 entry with ind2 of '0' or '1' is a Electronic Resource:
+    if (type === 'complete digital record') preFilter = (marcBlock) => ['0', '1'].indexOf(String(marcBlock.ind2)) >= 0
+    // Each 856 entry with ind2 of '2' (or blank/unset) is "Appendix" (bib.supplementaryContent):
+    if (type === 'supplementary content') preFilter = (marcBlock) => !marcBlock.ind2 || String(marcBlock.ind2).trim() === '' || ['2'].indexOf(String(marcBlock.ind2)) >= 0
+
+    // URLs and labels can be anywhere, so pass `null` subfields param to get them all
+    const electronicStuff = this.bib.varField(856, null, { tagSubfields: true, preFilter })
+
+    if (electronicStuff && electronicStuff.length > 0) {
+      return electronicStuff.map(({ subfieldMap }) => {
+        // Consider all subfield values:
+        const values = Object.values(subfieldMap).filter((content) => content)
+        // // varFields automatically concatenates subfields into one string, but we want to ignore that
+        // delete values.value
+        // Get the one that looks like a URL
+        const isUrl = (v) => /^https?:/.test(v)
+        const url = values.filter(isUrl)[0]
+        // .. and choose the label from the longest value that isn't a URL
+        const label = values.filter((v) => !isUrl(v)).sort((e1, e2) => e1.length > e2.length ? -1 : 1)[0]
+
+        return url ? { url, label } : null
+      }).filter((r) => r)
+    } else return null
+  }
+
+  _identifiers () {
+    let identifiers = []
+
+    // Add Bnumber as an identifier:
+    identifiers.push(
+      { value: this.bib.id, type: 'nypl:Bnumber' }
+    )
+
+    // Add ISBN(s):
+    if (this.idIsbn()) {
+      identifiers = identifiers.concat(
+        this.idIsbn().map((value) => ({ value, type: 'bf:Isbn' }))
+      )
+    }
+
+    // Add canceled/invalid ISBNs:
+    identifiers = identifiers.concat(
+      this.bib.varFieldsMulti(
+        BibMappings.get('isbnCanceledInvalid', this.bib)
+      ).map((value) => {
+        return { value, type: 'bf:Isbn', identifierStatus: 'canceled/invalid' }
+      })
+    )
+
+    // Add OCLC(s):
+    if (this.idOclc()) {
+      identifiers = identifiers.concat(
+        this.idOclc().map((value) => ({ value, type: 'nypl:Oclc' }))
+      )
+    }
+
+    // Add LCCN(s):
+    if (this.idLccn()) {
+      identifiers = identifiers.concat(
+        this.idLccn().map((value) => ({ value, type: 'nypl:Lccn' }))
+      )
+    }
+
+    // Add ISSN(s):
+    if (this.idIssn()) {
+      identifiers = identifiers.concat(
+        this.idIssn().map((value) => ({ value, type: 'nypl:Issn' }))
+      )
+    }
+
+    // Add canceled ISSNs:
+    identifiers = identifiers.concat(
+      this.bib.varFieldsMulti(
+        BibMappings.get('issnCanceled', this.bib)
+      ).map((value) => {
+        return { value, type: 'bf:Issn', identifierStatus: 'canceled' }
+      })
+    )
+
+    // Add incorrect ISSNs:
+    identifiers = identifiers.concat(
+      this.bib.varFieldsMulti(
+        BibMappings.get('issnIncorrect', this.bib)
+      ).map((value) => {
+        return { value, type: 'bf:Issn', identifierStatus: 'incorrect' }
+      })
+    )
+
+    // Add obscure system control numbers:
+    identifiers = identifiers.concat(
+      this.bib.varFieldsMulti(BibMappings.get('identifier', this.bib))
+        .filter((field) => {
+          // Filter out any of these identifiers that have already been added
+          // through more specific mappings above:
+          return !identifiers.some((otherIdentifier) => {
+            return otherIdentifier.id === field.value
+          })
+        })
+        .map((field) => {
+          return { value: field.value, type: 'bf:Identifier' }
+        })
+    )
+
+    // Add shelfmark (call number):
+    if (this.shelfMark()) {
+      identifiers = identifiers.concat(
+        this.shelfMark().map((value) => ({ value, type: 'bf:ShelfMark' }))
+      )
+    }
+
+    return identifiers
+  }
+
+  _isAeonUrl (url) {
+    const aeonLinks = [
+      'https://specialcollections.nypl.org/aeon/Aeon.dll',
+      'https://nypl-aeon-test.aeon.atlas-sys.com'
+    ]
+    return Boolean(aeonLinks.some((path) => url.startsWith(path)))
+  }
+
+  _languageCodes () {
+    let code = this.bib.varFieldSegment('008', [35, 37])
+    if (code) code = code.trim()
+    // Only accept 3-char lang codes:
+    if (code && code.length === 3) return [code]
+
+    return this.bib.varField('041', ['a'])
+      .map((match) => match.value.split(' '))
+      .reduce((acc, el) => acc.concat(el), [])
+  }
+
   _mediaTypeByVarField (useStrategies = ['337', '007']) {
     if (useStrategies.includes('007')) {
       const id = this.bib.varFieldSegment('007', [0, 0])
@@ -783,6 +809,36 @@ class EsBib extends EsBase {
         return [{ id: `mediatypes:${id}`, label }]
       }
     }
+  }
+
+  /**
+   * Returns an array of parallel note values rendered as parallelDisplayField
+   * entries
+   */
+  _parallelNotesAsDisplayFields () {
+    const notesArray = this._buildNotesArray()
+    return notesArray
+      // Convert the varfieldmatch objects into parallelDisplayField style
+      // objects:
+      .map(({ varFieldMatchObject, description }, index) => {
+        return {
+          value: parallelValue(varFieldMatchObject),
+          index,
+          fieldName: 'note'
+        }
+      })
+      // Now that we've assigned them index values, remove any that don't
+      // actually have any content:
+      .filter((parallelDisplayField) => parallelDisplayField.value)
+  }
+
+  // _this parameter exists for testing
+  _sortify (func, _this = this) {
+    let literal = _this[func]()
+    if (!literal) return null
+    literal = Array.isArray(literal) ? literal[0] : literal
+    if (typeof literal !== 'string') return null
+    return [literal.substring(0, 80).toLowerCase()]
   }
 }
 

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -9,6 +9,7 @@ const { pack } = require('../utils/packed-transform')
 const { titleSortTransform } = require('../utils/title-sort-transform')
 const { lookup } = require('../utils/lookup')
 const { getBibCallNum } = require('../utils/get-bib-call-num')
+const { unique } = require('../utils')
 
 class EsBib extends EsBase {
   constructor (sierraBib) {
@@ -235,7 +236,7 @@ class EsBib extends EsBase {
 
   items () {
     return this.bib.items()
-      .map(item => new EsItem(item))
+      .map(item => new EsItem(item, this))
       .concat(
         this.bib.holdings()
           .map(h => EsCheckinCardItem.fromSierraHolding(h))
@@ -271,6 +272,13 @@ class EsBib extends EsBase {
     if (this.idOclc()) {
       identifiers = identifiers.concat(
         this.idOclc().map((value) => ({ value, type: 'nypl:Oclc' }))
+      )
+    }
+
+    // Add LCCN(s):
+    if (this.idLccn()) {
+      identifiers = identifiers.concat(
+        this.idLccn().map((value) => ({ value, type: 'nypl:Lccn' }))
       )
     }
 
@@ -369,12 +377,35 @@ class EsBib extends EsBase {
   }
 
   idOclc () {
-    const oclcPrefix = /^\(OCoLC\)/
-    const oclcs = this._valueToIndexFromBasicMapping('oclcNumber')
-    if (!oclcs) return null
-    return oclcs
-      .filter((value) => oclcPrefix.test(value))
-      .map((value) => value.replace(oclcPrefix, ''))
+    let oclcs = []
+
+    ; [
+      { marc: '991', subfield: 'y' },
+      { marc: '035', subfield: 'a' },
+      { marc: '001' }
+    ].forEach((mapping) => {
+      let matches = this.bib.varField(mapping.marc, [mapping.subfield])
+
+      // Special handling for 035 values:
+      if (mapping.marc === '035') {
+        const oclcPrefix = /^\(OCoLC\)/
+        matches = matches
+          // Only consider 035 identifiers prefixed (OCoLC):
+          .filter((match) => {
+            return oclcPrefix.test(match.value)
+          })
+          // Strip (OCoLC) prefix:
+          .map((match) => {
+            match.value = match.value.replace(oclcPrefix, '')
+            return match
+          })
+      }
+
+      const newOclcs = matches.map((match) => match.value.trim())
+      oclcs = oclcs.concat(newOclcs)
+    })
+
+    return unique(oclcs)
   }
 
   issuance () {
@@ -513,7 +544,7 @@ class EsBib extends EsBase {
   }
 
   numElectronicResources () {
-    return this.electronicResources() ? this.electronicResources().length : 0
+    return [this.electronicResources() ? this.electronicResources().length : 0]
   }
 
   /**

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -397,8 +397,6 @@ class EsBib extends EsBase {
   }
 
   numItemVolumesParsed () {
-    const ranges = this.items()
-      .map((item) => item.volumeRange())
     const count = this.items()
       .filter((item) => item.volumeRange())
       .length

--- a/lib/es-models/checkin-card-item.js
+++ b/lib/es-models/checkin-card-item.js
@@ -115,7 +115,7 @@ class EsCheckinCardItem extends EsBase {
     let format = this.sierraHolding.varField('843', ['a']).shift()
     if (!format) {
       format = this.sierraHolding.fieldTag('i').shift()
-      if (format.value) {
+      if (format && format.value) {
         // Sometimes, fieldTag i looks like:
         //   "PRINT   JULY 10,1999-FEB 24 2001."
         // Grab the first token:
@@ -191,7 +191,7 @@ class EsCheckinCardItem extends EsBase {
    *  Get static checkin-card type
    */
   type () {
-    return [{ id: 'nypl:CheckinCardItem' }]
+    return ['nypl:CheckinCardItem']
   }
 
   uri () {

--- a/lib/es-models/holding.js
+++ b/lib/es-models/holding.js
@@ -24,15 +24,21 @@ class EsHolding extends EsBase {
         if (coverage.length > 0) coverage = `${coverage} (${dateStr})`
         else coverage = dateStr
       }
-      return {
-        shelfMark: this.shelfMark()[index],
-        copies: box.copy_count,
+      const shelfMark = this.shelfMark() ? this.shelfMark() : null
+      const serialization = {
+        shelfMark,
         coverage,
         position: box.box_count,
         status: box.status.label,
         type: 'nypl:CheckInBox'
       }
+      if (box.copy_count) {
+        serialization.copies = box.copy_count
+      }
+      return serialization
     })
+      // Sort checkin boxes by box number:
+      .sort((box1, box2) => box1.position - box2.position)
   }
 
   format () {
@@ -45,11 +51,8 @@ class EsHolding extends EsBase {
   }
 
   holdingStatement () {
-    if (this.holding.holdings) {
-      return this.holding.getHoldingStrings().map((h) => {
-        return this._valueToIndexFromBasicMapping('holdingStatement')
-      })
-    } else return null
+    const statements = this.holding.getHoldingStrings()
+    return statements.length ? statements : null
   }
 
   identifier () {
@@ -63,7 +66,7 @@ class EsHolding extends EsBase {
     if (location && sierraLocationMapping[location]) {
       const holdingLocationId = `loc:${location}`
       const holdingLocationLabel = sierraLocationMapping[location].label
-      return [{ id: holdingLocationId, label: holdingLocationLabel }]
+      return [{ code: holdingLocationId, label: holdingLocationLabel }]
     } else if (location) {
       logger.warn('Location id not recognized: ' + location)
     }
@@ -75,7 +78,7 @@ class EsHolding extends EsBase {
   // to be retrieved via the fieldTag method
   note () {
     const notes = this.holding.fieldTag('n')
-    if (notes) {
+    if (notes && notes.length) {
       return notes.map((n) => n.value)
     } else return null
   }
@@ -85,6 +88,7 @@ class EsHolding extends EsBase {
   }
 
   shelfMark () {
+    // Note that some holdings have multiple shelfmarks (e.g. h1089484)
     return this._valueToIndexFromBasicMapping('shelfMark')
   }
 

--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -9,6 +9,9 @@ const { coreObjectsMappingByCode } = require('../utils/core-objects-mapping-by-c
 const itemMapping = require('../mappings/item-mapping.json')
 const { lookup } = require('../utils/lookup')
 const statusMapping = require('@nypl/nypl-core-objects')('by-statuses')
+const { parseVolume } = require('../utils/volume-parse')
+const parseDate = require('../utils/item-date-parse')
+const { arrayToEsRangeObject } = require('../utils/es-ranges')
 
 class EsItem extends EsBase {
   constructor (sierraItem, bib) {
@@ -56,6 +59,16 @@ class EsItem extends EsBase {
 
   catalogItemType_packed () {
     return pack(this.catalogItemType())
+  }
+
+  dateRange () {
+    const fieldtagV = this.item.fieldTag('v')[0]
+    if (fieldtagV) {
+      const parsedDates = parseDate.checkCache(fieldtagV.value)
+      if (parsedDates && parsedDates.length) {
+        return parsedDates.map(arrayToEsRangeObject)
+      }
+    }
   }
 
   enumerationChronology () {
@@ -269,6 +282,16 @@ class EsItem extends EsBase {
 
   uri () {
     return `i${this.item.id}`
+  }
+
+  volumeRange () {
+    const fieldtagV = this.item.fieldTag('v')[0]
+    if (fieldtagV) {
+      const parsedVols = parseVolume(fieldtagV.value)
+      if (parsedVols && parsedVols.length) {
+        return parsedVols.map(arrayToEsRangeObject)
+      }
+    }
   }
 
   _accessMessageCode () {

--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -18,41 +18,6 @@ class EsItem extends EsBase {
     this.location = null
   }
 
-  _accessMessageCode () {
-    let accessMessageCode = null
-    const item = this.item
-    if (item.isPartnerRecord()) {
-      let message = item.varField('876', ['h'])
-      if (message && message.length > 0) {
-        message = message.pop()
-
-        // If 876 $h is 'IN LIBRARY USE' or [blank]:
-        if (message.toLowerCase() === 'in library use' || message.toLowerCase() === '') {
-          accessMessageCode = '1'
-
-          // If 876 $h is SUPERVISED USE:
-        } else if (message.toLowerCase() === 'supervised use') {
-          accessMessageCode = 'u'
-
-          // If 876 $h is set to anything else, try using fixed "OPAC Message"
-        } else if (item.fixed('OPAC Message')) {
-          accessMessageCode = item.fixed('OPAC Message')
-        }
-      }
-
-      // If we didn't find the partner access message in 876 $h, default to In Library Use:
-      if (!accessMessageCode) {
-        accessMessageCode = '1'
-      }
-
-      // Otherwise it's ours; look for OPAC Message:
-    } else if (item.fixed('OPAC Message')) {
-      accessMessageCode = item.fixed('OPAC Message')
-    }
-
-    return accessMessageCode
-  }
-
   // requires utils.coreObjectsMappingByCode
   accessMessage () {
     const accessMessageCode = this._accessMessageCode()
@@ -101,27 +66,11 @@ class EsItem extends EsBase {
     return null
   }
 
-  _location () {
-    if (this.location) return this.location
-    let location = null
-    const item = this.item
-    if (item.location) {
-      location = item.location.code
-    } else {
-      const altLocation = item.varField('852', ['b'])
-      if (altLocation && altLocation.length > 0) location = altLocation
+  formatLiteral () {
+    const bibMaterialType = this.bib.materialType()
+    if (bibMaterialType && bibMaterialType.length) {
+      return [bibMaterialType[0].label]
     }
-
-    if (location && sierraLocationMapping[location]) {
-      const holdingLocationId = `loc:${location}`
-      const holdingLocationLabel = sierraLocationMapping[location].label
-      this.location = { id: holdingLocationId, label: holdingLocationLabel, rawId: location }
-    } else if (location) {
-      // If it's an NYPL item, the extracted location should exist in our sierraLocationMapping, so warn:
-      if (item.isNyplRecord()) logger.warn('Location id not recognize: ', location)
-    }
-
-    return this.location
   }
 
   // needs sierraLocationMapping and logger
@@ -169,8 +118,8 @@ class EsItem extends EsBase {
   recapCustomerCode () {
     let literal = null
     const item = this.item
-    if (item.isNyplRecord() && item.recapCustomerCode) {
-      literal = item.recapCustomerCode
+    if (item.isNyplRecord() && item._recapCustomerCode) {
+      literal = item._recapCustomerCode
     } else if (!item.isNyplRecord()) {
       literal = item.varField('900', ['b'])[0]
     }
@@ -207,29 +156,47 @@ class EsItem extends EsBase {
     return [statusRequestable && locationRequestable && accessMessageRequestable && typeRequestable]
   }
 
-  _callNum () {
-    let callnum
-    const shelfMarkMarc = itemMapping.callNumber.paths[0].marc
-    const shelfMarkSubfields = itemMapping.callNumber.paths[0].subfields
+  aeonUrl () {
+    if (!this.bib) return null
+    const baseAeonUrl = this.bib._aeonUrls()
+
+    if (!baseAeonUrl) return null
+
+    const aeonUrl = baseAeonUrl
+      .replace(/Site=[^&]+/, 'Site=' + this._aeonSiteCode())
+
+    return [aeonUrl]
+  }
+
+  idBarcode () {
+    let barcode = null
     const item = this.item
-    if (item.varField(shelfMarkMarc, ['h'])) {
-      callnum = item.varField(shelfMarkMarc, shelfMarkSubfields)[0]
+    if (item.barcode) barcode = item.barcode
+    else if (item.varField('876', ['p']).length) barcode = item.varField('876', ['p'])[0]
+    if (barcode) return [barcode]
+  }
+
+  identifier () {
+    // Convert identifier entities into urn-style strings:
+    const urnPrefixMap = {
+      'bf:Barcode': 'barcode'
     }
-    // If not found in var field
-    if (!callnum) callnum = item.callNumber
-    // If not yet found, look in 945 $g
-    if (!callnum && item.varField('945', ['g']).length > 0) callnum = item.varField('945', ['g'])[0]
-    // If not found, default to callnum from bib
-    if (!callnum) {
-      const bibCallNum = this.bib && this.bib._callNum()
-      if (bibCallNum && bibCallNum.value) callnum = bibCallNum
-    }
-    // Sierra seems to put these '|h' prefixes on callnumbers; strip 'em
-    if (callnum && typeof callnum === 'object' && callnum.value) {
-      callnum = callnum.value
-    }
-    if (callnum) callnum = callnum.replace(/^\|h/, '')
-    return callnum
+
+    return this._identifier()
+      .map((identifier) => {
+        const prefix = urnPrefixMap[identifier.type] || 'identifier'
+        const value = identifier.value
+        return `urn:${prefix}:${value}`
+      })
+  }
+
+  identifierV2 () {
+    return this._identifier()
+  }
+
+  physicalLocation () {
+    const callnum = this._callNum()
+    return callnum ? [callnum] : []
   }
 
   // ToDO: getting callnum from bib
@@ -253,11 +220,6 @@ class EsItem extends EsBase {
     const sortableShelfMark = this._sortableShelfMark()
     if (!Array.isArray(sortableShelfMark) || !sortableShelfMark.length) return null
     return this._sortableShelfMark()[0]
-  }
-
-  physicalLocation () {
-    const callnum = this._callNum()
-    return callnum ? [callnum] : []
   }
 
   // trim ? coreObjectsMappingByCode
@@ -297,17 +259,51 @@ class EsItem extends EsBase {
     }
   }
 
-  // does match just mean == ?
-  aeonUrl () {
-    if (!this.bib) return null
-    const baseAeonUrl = this.bib._aeonUrls()
+  status_packed () {
+    return pack(this.status())
+  }
 
-    if (!baseAeonUrl) return null
+  type () {
+    return ['bf:Item']
+  }
 
-    const aeonUrl = baseAeonUrl
-      .replace(/Site=[^&]+/, 'Site=' + this._aeonSiteCode())
+  uri () {
+    return `i${this.item.id}`
+  }
 
-    return [aeonUrl]
+  _accessMessageCode () {
+    let accessMessageCode = null
+    const item = this.item
+    if (item.isPartnerRecord()) {
+      let message = item.varField('876', ['h'])
+      if (message && message.length > 0) {
+        message = message.pop()
+
+        // If 876 $h is 'IN LIBRARY USE' or [blank]:
+        if (message.toLowerCase() === 'in library use' || message.toLowerCase() === '') {
+          accessMessageCode = '1'
+
+          // If 876 $h is SUPERVISED USE:
+        } else if (message.toLowerCase() === 'supervised use') {
+          accessMessageCode = 'u'
+
+          // If 876 $h is set to anything else, try using fixed "OPAC Message"
+        } else if (item.fixed('OPAC Message')) {
+          accessMessageCode = item.fixed('OPAC Message')
+        }
+      }
+
+      // If we didn't find the partner access message in 876 $h, default to In Library Use:
+      if (!accessMessageCode) {
+        accessMessageCode = '1'
+      }
+
+      // Otherwise it's ours; look for OPAC Message:
+    } else if (item.fixed('OPAC Message')) {
+      accessMessageCode = item.fixed('OPAC Message')
+    }
+
+    return accessMessageCode
   }
 
   _aeonSiteCode () {
@@ -317,12 +313,52 @@ class EsItem extends EsBase {
       .shift()
   }
 
-  idBarcode () {
-    let barcode = null
+  _callNum () {
+    let callnum
+    const shelfMarkMarc = itemMapping.callNumber.paths[0].marc
+    const shelfMarkSubfields = itemMapping.callNumber.paths[0].subfields
     const item = this.item
-    if (item.barcode) barcode = item.barcode
-    else if (item.varField('876', ['p']).length) barcode = item.varField('876', ['p'])[0]
-    if (barcode) return [barcode]
+    if (item.varField(shelfMarkMarc, ['h'])) {
+      callnum = item.varField(shelfMarkMarc, shelfMarkSubfields)[0]
+    }
+    // If not found in var field
+    if (!callnum) callnum = item.callNumber
+    // If not yet found, look in 945 $g
+    if (!callnum && item.varField('945', ['g']).length > 0) callnum = item.varField('945', ['g'])[0]
+    // If not found, default to callnum from bib
+    if (!callnum) {
+      const bibCallNum = this.bib && this.bib._callNum()
+      if (bibCallNum && bibCallNum.value) callnum = bibCallNum
+    }
+    // Sierra seems to put these '|h' prefixes on callnumbers; strip 'em
+    if (callnum && typeof callnum === 'object' && callnum.value) {
+      callnum = callnum.value
+    }
+    if (callnum) callnum = callnum.replace(/^\|h/, '')
+    return callnum
+  }
+
+  _location () {
+    if (this.location) return this.location
+    let location = null
+    const item = this.item
+    if (item.location) {
+      location = item.location.code
+    } else {
+      const altLocation = item.varField('852', ['b'])
+      if (altLocation && altLocation.length > 0) location = altLocation
+    }
+
+    if (location && sierraLocationMapping[location]) {
+      const holdingLocationId = `loc:${location}`
+      const holdingLocationLabel = sierraLocationMapping[location].label
+      this.location = { id: holdingLocationId, label: holdingLocationLabel, rawId: location }
+    } else if (location) {
+      // If it's an NYPL item, the extracted location should exist in our sierraLocationMapping, so warn:
+      if (item.isNyplRecord()) logger.warn('Location id not recognize: ', location)
+    }
+
+    return this.location
   }
 
   _identifier () {
@@ -342,36 +378,6 @@ class EsItem extends EsBase {
       identifiers.push(barcode)
     }
     return identifiers
-  }
-
-  identifierV2 () {
-    return this._identifier()
-  }
-
-  identifier () {
-    // Convert identifier entities into urn-style strings:
-    const urnPrefixMap = {
-      'bf:Barcode': 'barcode'
-    }
-
-    return this._identifier()
-      .map((identifier) => {
-        const prefix = urnPrefixMap[identifier.type] || 'identifier'
-        const value = identifier.value
-        return `urn:${prefix}:${value}`
-      })
-  }
-
-  uri () {
-    return `i${this.item.id}`
-  }
-
-  _barcode () {
-
-  }
-
-  type () {
-    return ['bf:Item']
   }
 }
 

--- a/lib/general-prefetch.js
+++ b/lib/general-prefetch.js
@@ -1,7 +1,15 @@
-const { attachRecapCustomerCodes } = require('../lib/scsb/requests')
+const { attachRecapCustomerCodesToBibs } = require('../lib/scsb/requests')
+const { parseDatesAndCache } = require('../lib/utils/item-date-parse')
 
 const generalPrefetch = async (records) => {
-  records = await Promise.all(records.map(attachRecapCustomerCodes))
+  // Run a collection "prefetcher jobs", which are async functions that operate on a set of records:
+  await Promise.all([
+    // Look up ReCAP customer codes:
+    attachRecapCustomerCodesToBibs(records),
+    // Pre-parse item dates:
+    parseDatesAndCache(records)
+  ])
+
   return records
 }
 

--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -1073,6 +1073,7 @@
           "y",
           "z"
         ],
+        "options": { "subfieldJoiner": " -- " },
         "description": "Subject Added Entry-Personal Name"
       },
       {
@@ -1090,6 +1091,7 @@
           "y",
           "z"
         ],
+        "options": { "subfieldJoiner": " -- " },
         "description": "Subject Added Entry-Personal Name"
       },
       {
@@ -1107,6 +1109,7 @@
           "y",
           "z"
         ],
+        "options": { "subfieldJoiner": " -- " },
         "description": "Subject Added Entry-Personal Name"
       },
       {
@@ -1124,6 +1127,7 @@
           "y",
           "z"
         ],
+        "options": { "subfieldJoiner": " -- " },
         "description": "Subject Added Entry-Personal Name"
       },
       {
@@ -1141,6 +1145,7 @@
           "y",
           "z"
         ],
+        "options": { "subfieldJoiner": " -- " },
         "description": "Subject Added Entry-Personal Name"
       },
       {
@@ -1158,6 +1163,7 @@
           "y",
           "z"
         ],
+        "options": { "subfieldJoiner": " -- " },
         "description": "Subject Added Entry-Personal Name"
       },
       {
@@ -1175,6 +1181,7 @@
           "y",
           "z"
         ],
+        "options": { "subfieldJoiner": " -- " },
         "description": "Subject Added Entry-Personal Name"
       },
       {
@@ -1192,6 +1199,7 @@
           "y",
           "z"
         ],
+        "options": { "subfieldJoiner": " -- " },
         "description": "Subject Added Entry-Personal Name"
       }
     ]

--- a/lib/mappings/holding-mapping.json
+++ b/lib/mappings/holding-mapping.json
@@ -33,56 +33,6 @@
       }
     ]
   },
-  "holdingStatement": {
-    "paths": [
-      {
-        "marc": "866",
-        "subfields": [
-          "h"
-        ]
-      },
-      {
-        "marc": "853",
-        "subfields": [
-          "8",
-          "a",
-          "b",
-          "c",
-          "d",
-          "e",
-          "f",
-          "i",
-          "j",
-          "k",
-          "l"
-        ],
-        "notes": "Provides structure for metadata in 863 fields"
-      },
-      {
-        "marc": "863",
-        "subfields": [
-          "8",
-          "a",
-          "b",
-          "c",
-          "d",
-          "e",
-          "f",
-          "i",
-          "j",
-          "k",
-          "l"
-        ],
-        "notes": "Provides structured data as defined in 853 fields"
-      },
-      {
-        "notes": "Additional data drawn from the fieldTag 'h' fields"
-      },
-      {
-        "notes": "Pre-formatted statements also available in holdings.holding_statement field"
-      }
-    ]
-  },
   "location": {
     "paths": [
       {

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -113,7 +113,8 @@ const modelPrefetch = async (bibs) => {
     const [holdingsArray, itemsArray] = await Promise.all([_holdingsForBibs(bibs), _itemsForArrayOfBibs(bibs)])
     bibs.forEach((bib) => {
       const holdings = holdingsArray.filter((h) => {
-        return h.bibIds.some((bibId) => bibId === bib.id)
+        // The holding.bibIds array appears to be integers, whereas bib.id is a string, so coerce as strings for comparison:
+        return h.bibIds.some((bibId) => String(bibId) === String(bib.id))
       })
       bib._holdings = bib._holdings.concat(holdings)
     })

--- a/lib/scsb/requests.js
+++ b/lib/scsb/requests.js
@@ -47,4 +47,11 @@ const attachRecapCustomerCodes = async (bib) => {
   return bib
 }
 
-module.exports = { attachRecapCustomerCodes, private: { _createRecapCodeMap } }
+/**
+ *  Apply attachRecapCustomerCodes to all given bibs
+ */
+const attachRecapCustomerCodesToBibs = async (bibs) => {
+  return Promise.all(bibs.map(attachRecapCustomerCodes))
+}
+
+module.exports = { attachRecapCustomerCodes, attachRecapCustomerCodesToBibs, private: { _createRecapCodeMap } }

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -132,7 +132,7 @@ class SierraBase {
   }
 
   varFieldsMulti (marcObjects) {
-    return marcObjects.map(({ marc, subfields, opts }) => this.varField(marc, subfields, opts))
+    return marcObjects.map(({ marc, subfields, options }) => this.varField(marc, subfields, options))
       .flat()
       .filter(varField => varField)
   }

--- a/lib/sierra-models/bib.js
+++ b/lib/sierra-models/bib.js
@@ -15,11 +15,11 @@ class SierraBib extends SierraBase {
   }
 
   items () {
-    return this._items
+    return this._items || []
   }
 
   holdings () {
-    return this._holdings
+    return this._holdings || []
   }
 
   isInRecap () {

--- a/lib/sierra-models/holding.js
+++ b/lib/sierra-models/holding.js
@@ -28,7 +28,9 @@ class SierraHolding extends SierraBase {
   }
 
   getHoldingStrings () {
-    return this.holdings.map((holding) => holding.holding_string).filter((h) => h)
+    return (this.holdings || [])
+      .map((holding) => holding.holding_string)
+      .filter((h) => h)
   }
 }
 

--- a/lib/to-json.js
+++ b/lib/to-json.js
@@ -12,7 +12,12 @@ const toJson = async (model) => {
   const objectToJson = {}
   await Promise.all(
     methods.map(async (method) => {
-      objectToJson[method] = await model[method]()
+      const value = await model[method]()
+
+      // If method returns null, don't include property:
+      if (value === null) return
+
+      objectToJson[method] = value
     })
   )
   return objectToJson

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,11 +60,19 @@ const trimTrailingPunctuation = (s) => {
   return s.replace(/\s*(\/|:|,)\s*$/, '')
 }
 
+/**
+ *  Given an array, returns a new array with unique members
+ */
+const unique = (array) => {
+  return Array.from(new Set(array))
+}
+
 module.exports = {
   isValidResponse,
   bNumberWithCheckDigit,
   zeroPadString,
   leftPad,
   removeTrailingElementsMatching,
-  trimTrailingPunctuation
+  trimTrailingPunctuation,
+  unique
 }

--- a/lib/utils/item-date-parse-preparsing-objects.js
+++ b/lib/utils/item-date-parse-preparsing-objects.js
@@ -1,0 +1,146 @@
+/**
+ * These are objects with regex expressions and transform functions used to preparse
+ * date strings before they are sent to the date parse lambda
+ */
+
+const getAllFourDigitYears = {
+  matchExpression: /\b((?:16|17|18|19|20)\d{2})\b/g,
+  transform (range) {
+    const years = [...range.matchAll(this.matchExpression)]
+    if (!years.length) {
+      return null
+    } else if (years.length === 1) {
+      return [[years[0][1], years[0][1]]]
+    } else if (years.legnth === 2) {
+      return [years.map(year => year[1])]
+    } else return [[years[0][1], years[years.length - 1][1]]]
+  }
+}
+
+const theOnlyYearParsingWeNeed = {
+  matchExpression: /\b((?:16|17|18|19|20)\d{2})[-|/](\d{2})\b/g,
+  transform (range) {
+    const years = [...range.matchAll(this.matchExpression)]
+    const prefix = years[0][0].slice(0, 2)
+    let secondYear
+    if (years.length === 1) {
+      secondYear = years[0][2]
+    } else {
+      secondYear = years[years.length - 1][2]
+    }
+    return years[0][1] + '-' + prefix + secondYear
+  }
+}
+
+// If timetwister returns null values, try to return a date
+const returnOneYear = {
+  matchExpression: /(?:16|17|18|19|20)\d{2}/,
+  transform: function (range) {
+    const match = range.match(this.matchExpression)
+    if (match) {
+      return match[0]
+    }
+  }
+}
+
+const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June?', 'July?', 'Aug', 'Sept?', 'Oct', 'Nov', 'Dec']
+const monthPattern = `(${monthNames.join('|')}).?`
+const seasonNames = ['Win(ter)?', '(Autumn|Fall?)', 'Spr(ing)?', 'Sum(mer)?']
+const seasonPattern = `(${seasonNames.join('|')}).?`
+const monthOrSeasonPattern = `(${monthPattern}|${seasonPattern})`
+/**
+ * These are objects with regex expressions and transform functions used to preparse
+ * date strings before they are sent to the date parse lambda.
+ */
+const wholeDateObjects = {
+  // Extract values from inside parentheses; v. 5 (August 1990)
+  parens: {
+    matchExpression: /\((.+\b\d{4})\)/,
+    transform: function (range) {
+      const match = range.match(this.matchExpression)
+      return match[1]
+    },
+    exampleString: 'v. 5 (August 1990)'
+  },
+
+  // 1992:spring
+
+  colon: {
+    matchExpression: new RegExp(`\\d{4}:${monthOrSeasonPattern}`, 'i'),
+    transform (range) {
+      return range.split(':')[1] + ' ' + range.split(':')[0]
+    },
+    exampleString: '1992:spring'
+  },
+
+  // 1956/57-1981/82
+  twoYearRangeMulti: {
+    matchExpression: /(?<!(no|v)\.\s?)\d{4}\/(\d{4}|\d{2})-\d{4}\/(\d{4}|\d{2})/gi,
+    transform (ranges) {
+      // turn 1956/57-1981/82 into 1956-82 and 1956/57-2001/02 into 1956-2002
+      const range = ranges.match(/(\d{4})\/(\d{4}|\d{2})-\d{4}\/(\d{4}|\d{2})/)
+      // Take the second capture group and the fourth, which are the first year in the string and the last.
+      const start = range[1]
+      let end = range[3]
+      // for ranges that end up 1999-02, turn into 1999-2002
+      if (start.match(/^19/) && end.match(/^0\d/)) {
+        end = '20' + end
+      }
+      return start + '-' + end
+    },
+    exampleString: '1956/57-1981/82'
+  },
+  // 1895-1896/1897
+  yearRangeWithSlash: {
+    matchExpression: /(?<!(?:no|v)\.\s?)(\d{4}-)\d{4}\/(\d{4})/,
+    transform (range) {
+      const years = range.match(this.matchExpression)
+      return years[1] + years[2]
+    },
+    exampleString: '1895-1896/1897'
+  },
+
+  // 1991/1992 or 1991/92 but only if it is the only date range in the string
+  soloRangeSlash: {
+    matchExpression: /(?<!(?:no|v)\.?\s?)(?:^|\s|-)\d{4}\/(\d{4}|\d{2})/g,
+    transform: function (range) {
+      const rangeMatch = range.match(this.matchExpression)
+      return rangeMatch[0].replace(/\//, '-')
+    },
+    exampleString: '1991/1992'
+  },
+
+  // addressing mysterious bug in timetwister that causes null values for XX0X-0X ranges
+  shortYearBug: {
+    matchExpression: /(\d{4})-(0\d)/,
+    transform: function (range) {
+      const shortYear = range.match(this.matchExpression)[2]
+      const century = range.match(/^\d{2}/)[0]
+      return range.replace(/(?<=-)(0\d)/, century + shortYear)
+    },
+    exampleString: 'XX0X-0X'
+  },
+
+  // month-month/month ' May-June/July 1963,  Oct. 1961-Sept./Oct. 1962'
+  monthRangeWithSlash: {
+    matchExpression: /(?<=-)[a-z]{3,4}\.?\/|\/[a-z]{3,4}\./gi,
+    transform: function (range) {
+      return range.replace(this.matchExpression, '')
+    },
+    exampleString: ' May-June/July 1963, Oct. 1961-Sept./Oct. 1962'
+  },
+
+  removeSecondCopy: {
+    matchExpression: /\(second copy\)/,
+    transform: function (range) {
+      return range.replace('(second copy)', '')
+    }
+  }
+}
+
+module.exports = {
+  preparsingObjects: wholeDateObjects,
+  returnOneYear,
+  getAllFourDigitYears,
+  theOnlyYearParsingWeNeed
+}

--- a/lib/utils/item-date-parse.js
+++ b/lib/utils/item-date-parse.js
@@ -48,7 +48,6 @@ const batchDates = (batchSize, originalArray) => {
 let dateCache = {}
 
 const checkCache = (fieldtagv) => {
-  console.log('getting date for ', fieldtagv)
   return dateCache[fieldtagv]
 }
 
@@ -113,7 +112,6 @@ const parseDatesAndCache = async function (bibs, enableTimeTwister = false) {
     dateCache = dates.reduce((cache, date, i) => {
       return { ...cache, [date]: ranges[i] }
     }, {})
-    console.log('Built cache: ', dateCache)
   } catch (e) {
     console.error(e)
   }

--- a/lib/utils/item-date-parse.js
+++ b/lib/utils/item-date-parse.js
@@ -1,0 +1,202 @@
+const AWS = require('aws-sdk')
+const log = require('loglevel')
+
+const { preparsingObjects, returnOneYear, theOnlyYearParsingWeNeed, getAllFourDigitYears } = require('./item-date-parse-preparsing-objects')
+
+AWS.config.region = 'us-east-1'
+
+let lambda
+
+function lambdaClient () {
+  if (!lambda) lambda = new AWS.Lambda()
+  return lambda
+}
+
+/**
+ * Given an array of bibs that already have items attached, returns an
+ * array of the fieldtagvs from all items on the bib.
+ */
+const extractFieldtagvs = (bibs) => {
+  return bibs
+    .map((bib) => {
+      return bib.items()
+        .map((item) => {
+          const match = item.fieldTag('v')[0]
+          return match ? match.value : null
+        })
+    })
+    .flat()
+    .filter((fieldtagv) => fieldtagv)
+}
+
+/**
+ *
+ * @param {*} batchSize a number
+ * @param {*} originalArray array
+ * @returns a nested array whose elements have a maximum
+ *  length of batchsize
+ */
+
+const batchDates = (batchSize, originalArray) => {
+  const batches = []
+  for (let i = 0; i < originalArray.length; i += batchSize) {
+    batches.push(originalArray.slice(i, i + batchSize))
+  }
+  return batches
+}
+
+let dateCache = {}
+
+const checkCache = (fieldtagv) => {
+  console.log('getting date for ', fieldtagv)
+  return dateCache[fieldtagv]
+}
+
+const _parseOnlyYear = (dates) => {
+  if (!Array.isArray(dates)) dates = [dates]
+  return dates.map((date) => {
+    if (date.match(preparsingObjects.parens.matchExpression)) {
+      date = preparsingObjects.parens.transform(date)
+    }
+    // tease out years format XXXX-XX
+    if (date.match(theOnlyYearParsingWeNeed.matchExpression)) {
+      date = theOnlyYearParsingWeNeed.transform(date)
+    }
+    date = getAllFourDigitYears.transform(date)
+    return date
+  })
+}
+
+/**
+ *
+ * @param {*} dates, an array of strings representing field tag 'v'
+ * @param year, boolean indicating whether it is preparsing dates OR
+ *  doing year parsing
+ * @returns an array of those dates with some string manipulation
+ *  so the data plays nicely with timetwister OR array of those dates
+ *  returned with the years isolated
+ */
+
+const preparse = function (dates) {
+  return dates.map((date) => {
+    // do some string manipulation so data works better with timetwister lambda
+    Object.keys(preparsingObjects).forEach((preparse) => {
+      if (date.match(preparsingObjects[preparse].matchExpression)) {
+        date = preparsingObjects[preparse].transform(date)
+      }
+    })
+    return date
+  })
+}
+
+/**
+ * Returns true if string appears to have at least one 4-digit year
+ */
+const _has4DigitYear = (d) => /\b\d{4}\b/.test(d)
+
+/**
+ *
+ * @param {array} bibs an array of bibs with items attached
+ * @param {boolean} enableTimeTwister - Indicates whether to delegate parsing to the TimeTwister lambda
+ * @returns nothing, used for side effect of calling timetwister lambda and filling cache
+ */
+
+const parseDatesAndCache = async function (bibs, enableTimeTwister = false) {
+  const dates = extractFieldtagvs(bibs)
+    // remove anything that doesn't have at least a four digit year
+    // (minimum for a parsable date)
+    .filter(_has4DigitYear)
+  try {
+    let ranges
+    if (enableTimeTwister) ranges = await _parseDates(dates)
+    else ranges = _parseOnlyYear(dates)
+    dateCache = dates.reduce((cache, date, i) => {
+      return { ...cache, [date]: ranges[i] }
+    }, {})
+    console.log('Built cache: ', dateCache)
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+/**
+ * This function is used for testing the date parsing mechanism
+ * via scripts/check-date-parsing-targets.js and test/date-parse-test.js
+ */
+
+const _parseDates = async function (dates) {
+  if (!Array.isArray(dates)) dates = [dates]
+  const preparsedDates = preparse(dates)
+  try {
+    let ranges = await timeTwist(preparsedDates)
+    ranges = filterNulls(ranges, preparsedDates)
+    // ranges is returned super nested:
+    /**
+     * all fieldtagvs [
+        individual fieldtagv [
+          all parsed ranges [
+            individual range [date, date]
+          ]
+        ]
+      ]
+     *  */
+    return ranges
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+/**
+ *
+ * @param {*} preparsedDates, an array of strings
+ * @returns an array of parsed dates
+ */
+
+const timeTwist = async (preparsedDates) => {
+  const preparsedDatesBatches = batchDates(1000, preparsedDates)
+
+  log.debug(`Invoking lambda with ${preparsedDatesBatches.length} batches of ${preparsedDates.length} dates`)
+  const timetwistedDates = await Promise.all(preparsedDatesBatches.map(async (batch) => {
+    const params = {
+      FunctionName: 'DateParser-qa',
+      Payload: JSON.stringify({
+        path: '/',
+        body: JSON.stringify({ dates: batch })
+      })
+    }
+    try {
+      log.debug(`  Invoking lambda with ${params.Payload}`)
+      const { Payload } = await lambdaClient().invoke(params).promise()
+      // Extract date information from payload
+      const payloadParsed = batch
+        .map((date) => JSON.parse(JSON.parse(Payload).body).dates[date])
+      // Convert from object into nested array
+      const ranges = payloadParsed
+        .filter((result) => result)
+        .map((results) => results.map((result) => ([result.date_start, result.date_end])))
+      return ranges
+    } catch (error) {
+      console.error(error)
+    }
+  }))
+  log.debug('/Finished invoking dateparser lambda')
+  return timetwistedDates.flat()
+}
+
+const filterNulls = (rangesArray, preparsedDates) => {
+  return rangesArray.map((rangesPerFieldtagv, rangesArrayIndex) => {
+    return rangesPerFieldtagv.map((range) => {
+      // If both values of a range are null, try and match on a single year in fieldtagv
+      if (range[0] === null || range[1] === null) {
+        const singleYear = returnOneYear.transform(preparsedDates[rangesArrayIndex])
+        if (singleYear) {
+          return [singleYear, singleYear]
+        }
+        // need to explicitly return null for standardjs linting
+        return null
+      } else return range
+    })
+  })
+}
+
+module.exports = { parseDatesAndCache, checkCache, private: { _parseDates, _has4DigitYear, _parseOnlyYear } }

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -44,8 +44,14 @@ const buildLocalEsDocFromUri = async (nyplSource, id) => {
 
 if (type === 'bib') {
   Promise.all([buildLocalEsDocFromUri(nyplSource, id), currentDocument(argv.uri, indexName)])
-    .then(([[localEsRecord], liveEsRecord]) => {
-      printDiff(liveEsRecord, localEsRecord, argv.verbose === 'true')
+    .then(([{ recordsToIndex, recordsToDelete }, liveEsRecord]) => {
+      if (recordsToDelete.length) {
+        console.log('Indexer would delete this bib', recordsToDelete)
+      } else {
+        // The local ES record is the sole element in recordsToIndex
+        const localEsRecord = recordsToIndex[0]
+        printDiff(liveEsRecord, localEsRecord, argv.verbose === 'true')
+      }
     }).catch(e => {
       logger.error(e.message)
       die()

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -10,7 +10,11 @@
  *   node scripts/compare-with-indexed --envfile [path to .env] --uri [bnum] --activeIndex [boolean]
  */
 
-const argv = require('minimist')(process.argv.slice(2))
+const argv = require('minimist')(process.argv.slice(2), {
+  default: {
+    verbose: false
+  }
+})
 const dotenv = require('dotenv')
 dotenv.config({ path: argv.envfile || './config/qa.env' })
 
@@ -50,10 +54,11 @@ if (type === 'bib') {
       } else {
         // The local ES record is the sole element in recordsToIndex
         const localEsRecord = recordsToIndex[0]
-        printDiff(liveEsRecord, localEsRecord, argv.verbose === 'true')
+        printDiff(liveEsRecord, localEsRecord, argv.verbose)
       }
     }).catch(e => {
-      logger.error(e.message)
+      console.error(`Compare-With-Indexed encountered an error: ${e.message}`)
+      console.error(e.stack)
       die()
     })
 } else {

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -297,10 +297,18 @@ describe('EsBib', function () {
   })
 
   describe('idOclc', () => {
-    it('should return array containing oclc numbers', () => {
+    it('should extact prefixed OCLC numbers from 035', () => {
       const record = new SierraBib(require('../fixtures/bib-11055155.json'))
       const esBib = new EsBib(record)
+      // This is also a test of uniqueness since the OCLC in this fixture is
+      // stored in both the 035 and 001:
       expect(esBib.idOclc()).to.deep.equal(['2362202'])
+    })
+
+    it('should extract OCLC numbers from 001', () => {
+      const record = new SierraBib(require('../fixtures/bib-10001936.json'))
+      const esBib = new EsBib(record)
+      expect(esBib.idOclc()).to.deep.equal(['NYPG002001377-B'])
     })
   })
 
@@ -892,8 +900,8 @@ describe('EsBib', function () {
       expect(supplementaryContentRecord.electronicResources()).to.equal(null)
     })
     it('numElectronicResources', () => {
-      expect(electronicResourcesRecord.numElectronicResources()).to.equal(2)
-      expect(supplementaryContentRecord.numElectronicResources()).to.equal(0)
+      expect(electronicResourcesRecord.numElectronicResources()).to.deep.equal([2])
+      expect(supplementaryContentRecord.numElectronicResources()).to.deep.equal([0])
     })
     it('electronic resources, aeonlinks, and supplementary content', () => {
       const record = new SierraBib({
@@ -974,7 +982,7 @@ describe('EsBib', function () {
       })
       const esRecord = new EsBib(record)
       expect(esRecord.supplementaryContent().length).to.equal(1)
-      expect(esRecord.numElectronicResources()).to.equal(2)
+      expect(esRecord.numElectronicResources()).to.deep.equal([2])
       expect(esRecord._aeonUrls().length).to.equal(1)
     })
   })

--- a/test/unit/es-checkin-card-item.test.js
+++ b/test/unit/es-checkin-card-item.test.js
@@ -221,7 +221,7 @@ describe('EsCheckinCardItem', function () {
   describe('type', () => {
     it('returns static CheckinCardItem type', () => {
       expect(checkinCardItems[0].type()).to.deep.equal([
-        { id: 'nypl:CheckinCardItem' }
+        'nypl:CheckinCardItem'
       ])
     })
   })

--- a/test/unit/es-holding.test.js
+++ b/test/unit/es-holding.test.js
@@ -9,20 +9,24 @@ describe('EsHolding model', () => {
       const holding = new EsHolding(new SierraHolding(require('../fixtures/holding-1089484.json')))
       expect(holding.checkInBoxes()).to.deep.equal([
         {
-          copies: null,
           coverage: '20 (--)',
           position: 1,
           status: 'Bound',
           type: 'nypl:CheckInBox',
-          shelfMark: '*R-SIBL NK9509 .T722 Latest ed.'
+          shelfMark: [
+            '*R-SIBL NK9509 .T722 Latest ed.',
+            'JBM 07-158 Bound vols.'
+          ]
         },
         {
-          copies: null,
           coverage: '21 (--)',
           position: 2,
           status: 'Expected',
           type: 'nypl:CheckInBox',
-          shelfMark: 'JBM 07-158 Bound vols.'
+          shelfMark: [
+            '*R-SIBL NK9509 .T722 Latest ed.',
+            'JBM 07-158 Bound vols.'
+          ]
         }
       ])
     })
@@ -43,8 +47,8 @@ describe('EsHolding model', () => {
     it('returns holdingStatement', () => {
       const holding = new EsHolding(new SierraHolding(require('../fixtures/holding-1032862.json')))
       expect(holding.holdingStatement()).to.deep.equal([
-        ['1 v. no. (year) (month)', '1.1   2012 01/02'],
-        ['1 v. no. (year) (month)', '1.1   2012 01/02']
+        'Jan 1997-2011. INCOMPLETE',
+        '2012-01/02'
       ])
     })
   })
@@ -59,7 +63,7 @@ describe('EsHolding model', () => {
   describe('location', () => {
     const holding = new EsHolding(new SierraHolding(require('../fixtures/holding-1089484.json')))
     it('returns location for valid sierra code', () => {
-      expect(holding.location()).to.deep.equal([{ id: 'loc:slrb1', label: 'Science, Industry and Business Library (SIBL) - Reference' }])
+      expect(holding.location()).to.deep.equal([{ code: 'loc:slrb1', label: 'Science, Industry and Business Library (SIBL) - Reference' }])
     })
     it('returns null for unrecognized location', () => {
       const holding = new EsHolding(new SierraHolding({ location: { code: 'not a sierra code' } }))

--- a/test/unit/es-item-test.js
+++ b/test/unit/es-item-test.js
@@ -246,7 +246,7 @@ describe('EsItem', function () {
     describe('nypl record with recapCustomerCode', function () {
       it('should return the recapCustomerCode', function () {
         const record = new SierraItem(require('../fixtures/item-17145801.json'))
-        record.recapCustomerCode = 'NA'
+        record._recapCustomerCode = 'NA'
         const esItem = new EsItem(record)
         expect(esItem.recapCustomerCode()).to.deep.equal(['NA'])
       })

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -99,6 +99,7 @@ describe('index handler function', () => {
       expect(callback).to.have.been.calledWith(null, 'Wrote 1 doc(s)')
     })
   })
+
   describe('modelPrefetch', () => {
     it('calls platformApi#modelPrefetch', async () => {
       eventDecoderStub('Item')

--- a/test/unit/primary-and-parallel-values.test.js
+++ b/test/unit/primary-and-parallel-values.test.js
@@ -59,8 +59,9 @@ describe('primary and parallel values', () => {
       let mappings
 
       // This bib has a single primary 600 with a linked parallel that is tagged RTL
+      // Note the non-standard ' -- ' joiner, which is controlled by the subjectLiteral mapping
       mappings = BibMappings.get('subjectLiteral', bib)
-      expect(parallelValues(bib.varFieldsMulti(mappings))).to.deep.equal(['\u200F600 parallel value a 600 parallel value b'])
+      expect(parallelValues(bib.varFieldsMulti(mappings))).to.deep.equal(['\u200F600 parallel value a -- 600 parallel value b'])
 
       // This bib has a single orphaned parallel for marc 100 that is tagged RTL
       mappings = BibMappings.get('creatorLiteral', bib)

--- a/test/unit/sierra-base.test.js
+++ b/test/unit/sierra-base.test.js
@@ -62,6 +62,16 @@ describe('SierraBase', function () {
       expect(title[0].value).to.eq('Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan / Ashkhatasirutʻiamb Galust Shermazaniani.')
     })
 
+    it('returns varField top-level content (i.e. not subfields) when subfields are not specified', function () {
+      const record = new SierraBase(require('../fixtures/bib-10001936.json'))
+      const oclc = record.varField('001')
+      expect(oclc).to.deep.equal([
+        {
+          value: 'NYPG002001377-B'
+        }
+      ])
+    })
+
     it('able to return single string from all subfields, excluding some subfields', function () {
       const record = new SierraBase(require('../fixtures/bib-10001936.json'))
       // Get title using all subfields

--- a/test/unit/utils-checkin-card-date-parse.test.js
+++ b/test/unit/utils-checkin-card-date-parse.test.js
@@ -1,0 +1,30 @@
+const expect = require('chai').expect
+
+const { parseCheckinCardDate } = require('../../lib/utils/checkin-card-date-parse')
+
+describe('checkin-card-date-parse', () => {
+  ; [
+    { input: 'Mar. 2012', output: '2012-03-01' },
+    { input: 'Jan. 2012', output: '2012-01-01' },
+    { input: 'Jul. 10, 1999', output: '1999-07-10' },
+    { input: '2023', output: '2023-01-01' },
+    { input: 'Spr. 1999', output: '1999-04-01' },
+    // Note the assumption that Winter begins on Jan 1, when some might say
+    // "Winter '99" means "December 21, 1999". It's not perfectly clear which
+    // interpretation is more often correct in our data
+    { input: 'Winter 1999', output: '1999-01-01' }
+  ].forEach(({ input, output }) => {
+    it('parses parsable date string: ' + input, () => {
+      expect(parseCheckinCardDate(input)).to.eq(output)
+    })
+  })
+
+  it('returns null for non-parsable date strings', () => {
+    expect(parseCheckinCardDate('tomorrow')).to.eq(null)
+    expect(parseCheckinCardDate('Jan/Feb')).to.eq(null)
+    expect(parseCheckinCardDate('2')).to.eq(null)
+    expect(parseCheckinCardDate(2)).to.eq(null)
+    expect(parseCheckinCardDate(null)).to.eq(null)
+    expect(parseCheckinCardDate(undefined)).to.eq(null)
+  })
+})

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -1,0 +1,33 @@
+const expect = require('chai').expect
+
+const utils = require('../../lib/utils')
+
+describe('utils', () => {
+  describe('leftPad', function () {
+    it('left pads to specified length', function () {
+      expect(utils.leftPad('', 8)).to.equal('00000000')
+      expect(utils.leftPad('', 2)).to.equal('00')
+      expect(utils.leftPad('what', 8)).to.equal('0000what')
+    })
+
+    it('left pads with specified char', function () {
+      expect(utils.leftPad('', 8, ' ')).to.equal('        ')
+      expect(utils.leftPad('what', 8, ' ')).to.equal('    what')
+      expect(utils.leftPad('what', 8, '*')).to.equal('****what')
+    })
+
+    it('stringifies non-string inputs', function () {
+      expect(utils.leftPad(undefined, 3, ' ')).to.equal('   ')
+      expect(utils.leftPad(null, 3, ' ')).to.equal('   ')
+      expect(utils.leftPad(10, 3, ' ')).to.equal(' 10')
+      expect(utils.leftPad(true, 5, ' ')).to.equal(' true')
+    })
+  })
+
+  describe('unique', () => {
+    it('unique-ifies a simple array', () => {
+      expect(utils.unique(['1', '2', '1'])).to.deep.equal(['1', '2'])
+      expect(utils.unique(['1', '2', '1', '2', '3'])).to.deep.equal(['1', '2', '3'])
+    })
+  })
+})


### PR DESCRIPTION
EsItem:
 - Implement `EsItem.formatLiteral`
 - Ensure LCCNs are included in identifiers
 - Ensure ES model methods that return `null` are not included in to-json
 - Fix `idOclc` implementation
 - Fix `EsItem.aeonUrl` implementation

EsBib:
 - Fix bug relating holdings
 - Add `dateString`
 - Add `numCheckinCardItems`, `numItemDatesParsed`, `numItemVolumesParsed`, and `numItemsTotal`
 - Add " -- " joiner to `subjectLiteral` mapping

EsCheckinCardItem
 - Fix `formatLiteral`

EsHolding
 - Fix `holdingStatement`
 - Change `location.id` to `location.code`
 - Ensure `checkinBoxes` is sorted by `position`

Also 
 - Expands test coverage in a few areas
 - Alphabetizes `EsItem` and `EsBib` methods (sorry)
 - Fixes compare-with-indexed script, broken by recent changes to build-es-document
 - Adds item date parsing (and wires it up in general prefetch)
 - ToJson should not try to index `null` values
 - Passing "true" to `compare-with-indexed --verbose` should be optional