### PR TITLE
Fix indexing bug in EsCheckinCardItem.formatLiteral

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -263,7 +263,7 @@ class EsBib extends EsBase {
       .map(item => new EsItem(item, this))
       .concat(
         this.bib.holdings()
-          .map(h => EsCheckinCardItem.fromSierraHolding(h))
+          .map((h) => EsCheckinCardItem.fromSierraHolding(h, this))
           .reduce((acc, el) => acc.concat(el), [])
       )
   }

--- a/lib/es-models/checkin-card-item.js
+++ b/lib/es-models/checkin-card-item.js
@@ -16,11 +16,12 @@ class EsCheckinCardItem extends EsBase {
    *  Build a EsCheckinCardItem based on the given SierraHolding and
    *  checkin-card index
    */
-  constructor (sierraHolding, checkinCardIndex) {
+  constructor (sierraHolding, checkinCardIndex, esBib) {
     super()
     this.sierraHolding = sierraHolding
     this.checkinCardIndex = checkinCardIndex
     this.checkinCard = sierraHolding.checkInCards[checkinCardIndex]
+    this.esBib = esBib
   }
 
   /**
@@ -112,18 +113,14 @@ class EsCheckinCardItem extends EsBase {
    *  Get effective format from parent holding record
    */
   formatLiteral () {
-    let format = this.sierraHolding.varField('843', ['a']).shift()
-    if (!format) {
-      format = this.sierraHolding.fieldTag('i').shift()
-      if (format && format.value) {
-        // Sometimes, fieldTag i looks like:
-        //   "PRINT   JULY 10,1999-FEB 24 2001."
-        // Grab the first token:
-        format.value = format.value.split(/\s+/).shift()
-      }
+    let format = this.sierraHolding.varField('843', ['a']).shift()?.value
+    // If failed to find format in holding record, use bib material type:
+    if (!format && this.esBib) {
+      const bibMaterialType = this.esBib.materialType()
+      if (bibMaterialType && bibMaterialType[0]) format = bibMaterialType[0].label
     }
     if (!format) return null
-    return [format.value]
+    return [format]
   }
 
   /**
@@ -241,11 +238,11 @@ class EsCheckinCardItem extends EsBase {
    *  Given a SierraHolding instance, returns an array of EsCheckinCardItem
    *  instances parsed from it
    */
-  static fromSierraHolding (sierraHolding) {
+  static fromSierraHolding (sierraHolding, esBib) {
     if (!sierraHolding.checkInCards) return []
 
     return sierraHolding.checkInCards.map((checkinCard, index) => {
-      return new EsCheckinCardItem(sierraHolding, index)
+      return new EsCheckinCardItem(sierraHolding, index, esBib)
     })
   }
 }

--- a/test/unit/es-checkin-card-item.test.js
+++ b/test/unit/es-checkin-card-item.test.js
@@ -2,6 +2,7 @@ const expect = require('chai').expect
 
 const SierraHolding = require('../../lib/sierra-models/holding')
 const EsCheckinCardItem = require('../../lib/es-models/checkin-card-item')
+const EsBib = require('../../lib/es-models/bib')
 
 describe('EsCheckinCardItem', function () {
   const holding = new SierraHolding(require('../fixtures/holding-1032862.json'))
@@ -110,13 +111,16 @@ describe('EsCheckinCardItem', function () {
       ])
     })
 
-    it('returns holding format', () => {
+    it('returns parent bib material type label as holding format when holding lacks 843', () => {
+      // Create a holding from which to extract checkin card items:
       const holding = new SierraHolding(require('../fixtures/holding-1044923.json'))
-      const items = EsCheckinCardItem.fromSierraHolding(holding)
-      // First item has null enumeration.enumeration
-      // and start_date "Jul. 10, 1999" (and null end_date), so:
+      // Create a esBib instance with a "Text" materialType:
+      const esBib = new EsBib(new SierraHolding(require('../fixtures/bib-10554371.json')))
+      const items = EsCheckinCardItem.fromSierraHolding(holding, esBib)
+      // Because the holding record doesn't have a 843, we expect checkin card
+      // items to derive formatLiteral from the esBib.materialType:
       expect(items[0].formatLiteral()).to.deep.equal([
-        'PRINT'
+        'Text'
       ])
     })
   })


### PR DESCRIPTION
Fix bug where extracted checkin card formatLiteral try to use holding fieldtag i (probably because EsHolding.format does that?). But I don't think this is correct; EsCheckinCardItem.formatLiteral should instead fall back on EsBib.materialType to replicate what DFE has been doing.