### PR TITLE
Fix small bugs

### DIFF
--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -173,9 +173,9 @@ class EsItem extends EsBase {
     if (!this.bib) return null
     const baseAeonUrl = this.bib._aeonUrls()
 
-    if (!baseAeonUrl) return null
+    if (!baseAeonUrl || !baseAeonUrl.length) return null
 
-    const aeonUrl = baseAeonUrl
+    const aeonUrl = baseAeonUrl[0]
       .replace(/Site=[^&]+/, 'Site=' + this._aeonSiteCode())
 
     return [aeonUrl]
@@ -331,8 +331,9 @@ class EsItem extends EsBase {
 
   _aeonSiteCode () {
     return (this.item.fieldTag('x') || [])
-      .filter((noteContent) => noteContent.startsWith('AEON eligible'))
-      .map((noteContent) => noteContent.replace(/^AEON eligible /, ''))
+      .map(noteContent => noteContent && noteContent.value)
+      .filter((noteContent) => noteContent && noteContent.startsWith('AEON eligible'))
+      .map((noteContent) => noteContent && noteContent.replace(/^AEON eligible /, ''))
       .shift()
   }
 

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -44,8 +44,13 @@ class SierraBase {
   _cacheParallels () {
     const parallels = this._varFieldByMarcTag(880)
     return parallels.reduce((acc, parallelField) => {
-      const { tag, number } = this._parseSubfield6(parallelField)
-      return { ...acc, [tag + '-' + number]: parallelField }
+      const parsedSubfield6 = this._parseSubfield6(parallelField)
+      if (parsedSubfield6 && parsedSubfield6.tag && parsedSubfield6.number) {
+        const { tag, number } = this._parseSubfield6(parallelField)
+        return { ...acc, [tag + '-' + number]: parallelField }
+      }
+
+      return { ...acc }
     }, {})
   }
 


### PR DESCRIPTION
Fixes some small issues that have come up while running the DHI tester. Mostly adds some extra defensive programming, but also a couple of places where types are wrong 
1. It seems `noteContent` is of the form `{value: string}` not `string`
2. It seems baseAeonUrl is of the form `[string]` not `string`

We should probably hold off on merging this until the bugs are fully sorted out  