### PR TITLE
replace stub

### DIFF
--- a/lib/elastic-search/requests.js
+++ b/lib/elastic-search/requests.js
@@ -131,7 +131,7 @@ const getBibIdentifiersForItemId = async (nyplSource, itemId) => {
   })
 
   return record.hits.hits.map((hit) => hit._source.uri)
-    .map((uri) => NyplSourceMapper.instance().splitIdentifier(uri))
+    .map((uri) => (new NyplSourceMapper()).splitIdentifier(uri))
 }
 
 module.exports = {

--- a/lib/elastic-search/requests.js
+++ b/lib/elastic-search/requests.js
@@ -131,7 +131,7 @@ const getBibIdentifiersForItemId = async (nyplSource, itemId) => {
   })
 
   return record.hits.hits.map((hit) => hit._source.uri)
-    .map((uri) => (new NyplSourceMapper()).splitIdentifier(uri))
+    .map((uri) => NyplSourceMapper.instance().splitIdentifier(uri))
 }
 
 module.exports = {

--- a/lib/elastic-search/requests.js
+++ b/lib/elastic-search/requests.js
@@ -1,5 +1,7 @@
 const es = require('./client')
 const logger = require('../logger')
+const NyplSourceMapper = require('../utils/nypl-source-mapper')
+const { uriForRecordIdentifier } = require('../utils/uriForRecordIdentifier')
 
 // takes array of JSON-ified EsBib records and indexes them to index specified in env vars
 // indexing creates or overwrites existing doc
@@ -104,4 +106,37 @@ const currentDocument = async (bibId, index) => {
   return record.hits.hits[0]._source
 }
 
-module.exports = { currentDocument, writeRecords, internal: { _indexGeneric } }
+const getBibIdentifiersForItemId = async (nyplSource, itemId) => {
+  const itemUri = await uriForRecordIdentifier(nyplSource, itemId, 'item')
+
+  logger.debug(`Getting bibIds for item ${itemUri}`)
+
+  const query = {
+    nested: {
+      path: 'items',
+      query: {
+        term: {
+          'items.uri': itemUri
+        }
+      }
+    }
+  }
+  const client = await es.client()
+  const record = await client.search({
+    index: process.env.ELASTIC_RESOURCES_INDEX_NAME,
+    body: {
+      query,
+      _source: ['uri']
+    }
+  })
+
+  return record.hits.hits.map((hit) => hit._source.uri)
+    .map((uri) => (new NyplSourceMapper()).splitIdentifier(uri))
+}
+
+module.exports = {
+  currentDocument,
+  writeRecords,
+  getBibIdentifiersForItemId,
+  internal: { _indexGeneric }
+}

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -117,7 +117,7 @@ class EsBib extends EsBase {
   }
 
   dateEndString () {
-    const year = this.bib.varFieldSegment('008', [11, 14]).trim()
+    const year = this.bib.varFieldSegment('008', [11, 14])?.trim()
     return year ? [year] : null
   }
 

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -117,13 +117,16 @@ class EsBib extends EsBase {
   }
 
   dateEndString () {
-    return [this.bib.varFieldSegment('008', [11, 14])]
+    const year = this.bib.varFieldSegment('008', [11, 14]).trim()
+    return year ? [year] : null
   }
 
   dateEndYear () {
     // TODO: Handle '9999', etc
-    return this.dateEndString()
-      .map((date) => parseInt(date))
+    const dateString = this.dateEndString()
+    return dateString
+      ? dateString.map((date) => parseInt(date))
+      : null
   }
 
   dateStartYear () {
@@ -216,7 +219,7 @@ class EsBib extends EsBase {
   idOclc () {
     let oclcs = []
 
-    ; [
+      ;[
       { marc: '991', subfield: 'y' },
       { marc: '035', subfield: 'a' },
       { marc: '001' }
@@ -227,11 +230,11 @@ class EsBib extends EsBase {
       if (mapping.marc === '035') {
         const oclcPrefix = /^\(OCoLC\)/
         matches = matches
-          // Only consider 035 identifiers prefixed (OCoLC):
+        // Only consider 035 identifiers prefixed (OCoLC):
           .filter((match) => {
             return oclcPrefix.test(match.value)
           })
-          // Strip (OCoLC) prefix:
+        // Strip (OCoLC) prefix:
           .map((match) => {
             match.value = match.value.replace(oclcPrefix, '')
             return match

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -6,6 +6,7 @@ const {
   filteredSierraItemsForItems,
   filteredSierraHoldingsForHoldings
 } = require('../prefilter')
+const { getBibIdentifiersForItemId } = require('../elastic-search/requests')
 
 /**
  *
@@ -200,8 +201,32 @@ const _bibIdentifiersForHoldings = (holdings) => {
 }
 
 const _bibIdentifiersForItems = async (items) => {
-  const ids = await Promise.all(items.map((i) => Promise.resolve([{ id: 'b' + i.id, nyplSource: 'Tatooine' }])))
-  return ids.flat()
+  let identifiers = await Promise.all(
+    items.map(async (item) => {
+      if (item.bibIds && Array.isArray(item.bibIds) && item.bibIds.length > 0) {
+        return item.bibIds
+          .map((id) => {
+            console.log({ nyplSource: item.nyplSource, id })
+            return { nyplSource: item.nyplSource, id }
+          })
+      } else {
+        // No bibIds? Probably a deleted item. Look up bibIds via DiscoveryAPI
+        return await getBibIdentifiersForItemId(item.nyplSource, item.id)
+      }
+    })
+  )
+  // Turn this array of arrays of identifiers into an array of identifiers
+  identifiers = identifiers.flat()
+    // And remove any for which we couldn't resolve a bibId
+    .filter((identifier) => identifier)
+
+  // De-dupe:
+  return Object.values(
+    identifiers.reduce((h, identifier) => {
+      h[JSON.stringify(identifier)] = identifier
+      return h
+    }, {})
+  )
 }
 
 module.exports = {

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -205,10 +205,8 @@ const _bibIdentifiersForItems = async (items) => {
     items.map(async (item) => {
       if (item.bibIds && Array.isArray(item.bibIds) && item.bibIds.length > 0) {
         return item.bibIds
-          .map((id) => {
-            console.log({ nyplSource: item.nyplSource, id })
-            return { nyplSource: item.nyplSource, id }
-          })
+          .map((id) => ({ nyplSource: item.nyplSource, id })
+          )
       } else {
         // No bibIds? Probably a deleted item. Look up bibIds via DiscoveryAPI
         return await getBibIdentifiersForItemId(item.nyplSource, item.id)

--- a/lib/utils/nypl-source-mapper.js
+++ b/lib/utils/nypl-source-mapper.js
@@ -4,7 +4,6 @@ class NyplSourceMapper {
   async nyplSourceMapping () {
     if (!this.nyplSourceMap) {
       const resp = await axios.get(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'master'}/mappings/recap-discovery/nypl-source-mapping.json`)
-      console.log(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'master'}/mappings/recap-discovery/nypl-source-mapping.json`)
       const mappingData = resp.data
       this.nyplSourceMap = mappingData
     }

--- a/lib/utils/nypl-source-mapper.js
+++ b/lib/utils/nypl-source-mapper.js
@@ -4,6 +4,7 @@ class NyplSourceMapper {
   async nyplSourceMapping () {
     if (!this.nyplSourceMap) {
       const resp = await axios.get(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'master'}/mappings/recap-discovery/nypl-source-mapping.json`)
+      console.log(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'master'}/mappings/recap-discovery/nypl-source-mapping.json`)
       const mappingData = resp.data
       this.nyplSourceMap = mappingData
     }

--- a/lib/utils/uriForRecordIdentifier.js
+++ b/lib/utils/uriForRecordIdentifier.js
@@ -14,7 +14,7 @@ const NyplSourceMapper = require('./nypl-source-mapper')
  *    => 'cb9876'
  */
 const uriForRecordIdentifier = async function (nyplSource, id, type = 'item') {
-  const nyplSourceMapping = await (new NyplSourceMapper()).nyplSourceMapping()
+  const nyplSourceMapping = await NyplSourceMapper.instance().nyplSourceMapping()
 
   if (!nyplSourceMapping[nyplSource]) return null
 

--- a/lib/utils/uriForRecordIdentifier.js
+++ b/lib/utils/uriForRecordIdentifier.js
@@ -14,7 +14,7 @@ const NyplSourceMapper = require('./nypl-source-mapper')
  *    => 'cb9876'
  */
 const uriForRecordIdentifier = async function (nyplSource, id, type = 'item') {
-  const nyplSourceMapping = await NyplSourceMapper.instance().nyplSourceMapping()
+  const nyplSourceMapping = await (new NyplSourceMapper()).nyplSourceMapping()
 
   if (!nyplSourceMapping[nyplSource]) return null
 

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -20,7 +20,7 @@ const argv = require('minimist')(process.argv.slice(2), {
 const dotenv = require('dotenv')
 dotenv.config({ path: argv.envfile || './config/qa.env' })
 
-const NyplSourceMapper = require('discovery-store-models/lib/nypl-source-mapper')
+const NyplSourceMapper = require('../lib/utils/nypl-source-mapper')
 const { awsInit, die, printDiff } = require('./utils')
 const { bibById } = require('../lib/platform-api/requests')
 const { buildEsDocument } = require('../lib/build-es-document')
@@ -41,7 +41,7 @@ let indexName = process.env.ELASTIC_RESOURCES_INDEX_NAME
 if (!argv.uri) usage() && die('Must specify event file or uri')
 if (argv.activeIndex === 'true') indexName = process.env.HYBRID_ES_INDEX
 
-const { id, type, nyplSource } = NyplSourceMapper.instance().splitIdentifier(argv.uri)
+const { id, type, nyplSource } = (new NyplSourceMapper()).splitIdentifier(argv.uri)
 
 const buildLocalEsDocFromUri = async (nyplSource, id) => {
   const bib = await bibById(nyplSource, id)

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -3,11 +3,13 @@
  * Given a bib uri, generates the ES doc using local code and then
  * fetches the same record from the remote index to perform a comparison.
  * When true is provided for active-index, the script  will query the index
- * that is updated by the DHI. Otherwise, it will go to the research-catalog-indexer
- * test index.
+ * that is updated by the DHI (provided in the config file as HYBRID_ES_INDEX).
+ * Otherwise, it will compare against the research-catalog-indexer test index.
+ * If --verbose is true, the diff will show the differing values from each record,
+ * instead of reporting only that there is a diff.
  *
  * Usage:
- *   node scripts/compare-with-indexed --envfile [path to .env] --uri [bnum] --activeIndex [boolean]
+ *   node scripts/compare-with-indexed --envfile [path to .env] --uri [bnum] --activeIndex [boolean] --verbose [boolean]
  */
 
 const argv = require('minimist')(process.argv.slice(2), {
@@ -39,7 +41,7 @@ let indexName = process.env.ELASTIC_RESOURCES_INDEX_NAME
 if (!argv.uri) usage() && die('Must specify event file or uri')
 if (argv.activeIndex === 'true') indexName = process.env.HYBRID_ES_INDEX
 
-const { id, type, nyplSource } = NyplSourceMapper.instance().splitIdentifier(argv.uri)
+const { id, type, nyplSource } = (new NyplSourceMapper()).splitIdentifier(argv.uri)
 
 const buildLocalEsDocFromUri = async (nyplSource, id) => {
   const bib = await bibById(nyplSource, id)

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -41,7 +41,7 @@ let indexName = process.env.ELASTIC_RESOURCES_INDEX_NAME
 if (!argv.uri) usage() && die('Must specify event file or uri')
 if (argv.activeIndex === 'true') indexName = process.env.HYBRID_ES_INDEX
 
-const { id, type, nyplSource } = (new NyplSourceMapper()).splitIdentifier(argv.uri)
+const { id, type, nyplSource } = NyplSourceMapper.instance().splitIdentifier(argv.uri)
 
 const buildLocalEsDocFromUri = async (nyplSource, id) => {
   const bib = await bibById(nyplSource, id)

--- a/scripts/reindex-record.js
+++ b/scripts/reindex-record.js
@@ -80,7 +80,7 @@ const reindexBib = async (nyplSource, id) => {
 }
 
 if (argv.uri) {
-  const { id, type, nyplSource } = (new NyplSourceMapper()).splitIdentifier(argv.uri)
+  const { id, type, nyplSource } = NyplSourceMapper.instance().splitIdentifier(argv.uri)
   switch (type) {
     case 'bib':
       reindexBib(nyplSource, id)

--- a/scripts/reindex-record.js
+++ b/scripts/reindex-record.js
@@ -80,7 +80,7 @@ const reindexBib = async (nyplSource, id) => {
 }
 
 if (argv.uri) {
-  const { id, type, nyplSource } = NyplSourceMapper.instance().splitIdentifier(argv.uri)
+  const { id, type, nyplSource } = (new NyplSourceMapper()).splitIdentifier(argv.uri)
   switch (type) {
     case 'bib':
       reindexBib(nyplSource, id)

--- a/test/fixtures/bib-11606020.json
+++ b/test/fixtures/bib-11606020.json
@@ -401,7 +401,7 @@
       "marcTag": "008",
       "ind1": " ",
       "ind2": " ",
-      "content": "920623s1823    enk           00  0beng dcam a ",
+      "content": "920623s18232000enk           00  0beng dcam a ",
       "subfields": null
     },
     {

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1012,7 +1012,7 @@ describe('EsBib', function () {
     })
   })
 
-  describe.only('dateEnd', () => {
+  describe('dateEnd', () => {
     it('dateEndString should return null for no year', () => {
       const bib = new EsBib(new SierraBib(require('../fixtures/bib-10001936')))
       expect(bib.dateEndString()).to.equal(null)

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1012,6 +1012,25 @@ describe('EsBib', function () {
     })
   })
 
+  describe.only('dateEnd', () => {
+    it('dateEndString should return null for no year', () => {
+      const bib = new EsBib(new SierraBib(require('../fixtures/bib-10001936')))
+      expect(bib.dateEndString()).to.equal(null)
+    })
+    it('dateEndString should return array with year', () => {
+      const bib = new EsBib(new SierraBib(require('../fixtures/bib-11606020.json')))
+      expect(bib.dateEndString()).to.deep.equal(['2000'])
+    })
+    it('dateEndYear should return null for no year', () => {
+      const bib = new EsBib(new SierraBib(require('../fixtures/bib-10001936')))
+      expect(bib.dateEndYear()).to.equal(null)
+    })
+    it('dateEndYear should return year as int', () => {
+      const bib = new EsBib(new SierraBib(require('../fixtures/bib-11606020.json')))
+      expect(bib.dateEndYear()).to.deep.equal([2000])
+    })
+  })
+
   describe('items', () => {
     let bib
 


### PR DESCRIPTION
We noticed a stubbed function that never got un-stubbed. Mostly copied functions from discovery-api-indexer. 