### PR TITLE
Scc 3680 addtl

### DIFF
--- a/lib/elastic-search/requests.js
+++ b/lib/elastic-search/requests.js
@@ -41,7 +41,15 @@ const writeRecords = async (records) => {
     const errors = resp.items?.map((item) => item.index?.error)
     let message = 'Unknown error'
     if (errors) {
-      message = errors.map((error) => `${error.type}: ${error.reason}`)
+      message = errors
+        .map((error, i) => {
+          if (error) {
+            const record = records[i]
+            return `Error updating ${record.uri}: ` + (error.type ? `${error.type}: ${error.reason}` : error)
+          }
+          return null
+        })
+        .filter((e) => e)
         .join('; ')
     }
     logger.error(`Indexing error: ${message}`)

--- a/lib/es-models/base.js
+++ b/lib/es-models/base.js
@@ -18,15 +18,16 @@ class EsBase {
     if (!this.shelfMark) return null
 
     const shelfMarkArray = this.shelfMark()
-    if (!shelfMarkArray) return null
+    if (!shelfMarkArray || !shelfMarkArray[0]) {
+      // Order by id if we have no call numbers, but make sure these items
+      // go after items with call numbers
+      return 'b' + this.uri()
+    }
+
     const shelfMark = shelfMarkArray.shift()
     if (shelfMark) {
       // order by call number; Put these items first
       return 'a' + sortableShelfMark(this.shelfMark()[0])
-    } else {
-      // Order by id if we have no call numbers, but make sure these items
-      // go after items with call numbers
-      return 'b' + this.uri()
     }
   }
 
@@ -60,6 +61,12 @@ class EsBase {
   }
 
   _valueToIndexFromBasicMapping (field, primary = true) {
+    const fields = this._varFieldMatchesForBasicMapping(field)
+    const values = primary ? primaryValues(fields) : parallelValues(fields)
+    return values.length === 0 ? null : values.map(trimTrailingPunctuation)
+  }
+
+  _varFieldMatchesForBasicMapping (field) {
     // due to implcit binding, `this` refers to the object where this method is called, which is an Elastic Search model (bib, item, or holding)
     const esRecordType = this.constructor.name
     let mapping
@@ -77,9 +84,7 @@ class EsBase {
       record = 'bib'
     }
     const mappings = mapping.get(field, this[record])
-    const fields = this[record].varFieldsMulti(mappings)
-    const values = primary ? primaryValues(fields) : parallelValues(fields)
-    return values.length === 0 ? null : values.map(trimTrailingPunctuation)
+    return this[record].varFieldsMulti(mappings)
   }
 }
 

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -215,7 +215,8 @@ class EsBib extends EsBase {
   }
 
   idLccn () {
-    return this._valueToIndexFromBasicMapping('lccn')
+    const lccns = this._valueToIndexFromBasicMapping('lccn')
+    return lccns ? lccns.map((v) => v.trim()) : null
   }
 
   idOclc () {
@@ -247,7 +248,8 @@ class EsBib extends EsBase {
       oclcs = oclcs.concat(newOclcs)
     })
 
-    return unique(oclcs)
+    oclcs = unique(oclcs)
+    return oclcs.length ? oclcs : null
   }
 
   issuance () {
@@ -274,7 +276,7 @@ class EsBib extends EsBase {
   }
 
   language () {
-    return this._languageCodes()
+    const languageEntities = this._languageCodes()
       // Add lang label from lookup
       .map((code) => {
         const label = lookup('lookup-language-code-to-label')[code] || ''
@@ -283,6 +285,7 @@ class EsBib extends EsBase {
           label
         }
       })
+    return languageEntities.length ? languageEntities : null
   }
 
   language_packed () {
@@ -729,9 +732,11 @@ class EsBib extends EsBase {
     identifiers = identifiers.concat(
       this.bib.varFieldsMulti(
         BibMappings.get('isbnCanceledInvalid', this.bib)
-      ).map((value) => {
-        return { value, type: 'bf:Isbn', identifierStatus: 'canceled/invalid' }
-      })
+      )
+        .filter((match) => match.value)
+        .map((match) => {
+          return { value: match.value, type: 'bf:Isbn', identifierStatus: 'canceled/invalid' }
+        })
     )
 
     // Add OCLC(s):
@@ -759,9 +764,11 @@ class EsBib extends EsBase {
     identifiers = identifiers.concat(
       this.bib.varFieldsMulti(
         BibMappings.get('issnCanceled', this.bib)
-      ).map((value) => {
-        return { value, type: 'bf:Issn', identifierStatus: 'canceled' }
-      })
+      )
+        .filter((match) => match.value)
+        .map((match) => {
+          return { value: match.value, type: 'bf:Issn', identifierStatus: 'canceled' }
+        })
     )
 
     // Add incorrect ISSNs:

--- a/lib/es-models/checkin-card-item.js
+++ b/lib/es-models/checkin-card-item.js
@@ -145,11 +145,15 @@ class EsCheckinCardItem extends EsBase {
    */
   shelfMark () {
     const mappings = HoldingMappings.get('shelfMark', this.sierraHolding)
-    return this.sierraHolding.varFieldsMulti(mappings)
+    let shelfMarks = this.sierraHolding.varFieldsMulti(mappings)
       .map((varFieldMatch) => {
         // Sierra seems to put these '|h' prefixes on callnumbers; strip 'em
         return varFieldMatch.value.replace(/^\|h/, '')
       })
+    if (shelfMarks.length === 0 && this.esBib) {
+      shelfMarks = this.esBib.shelfMark()
+    }
+    return shelfMarks.length ? shelfMarks : null
   }
 
   shelfMark_sort () {

--- a/lib/es-models/holding.js
+++ b/lib/es-models/holding.js
@@ -10,35 +10,37 @@ class EsHolding extends EsBase {
   }
 
   checkInBoxes () {
-    const boxes = this.holding.checkInCards || []
-    return boxes.map((box, index) => {
-      // Create coverage string
-      let coverage = ''
-      // Get any enumeration associated with this box
-      if (box.enumeration.enumeration) coverage = box.enumeration.enumeration
-      let dateStr
-      if (box.start_date || box.end_date) {
-        if (box.start_date) dateStr = box.start_date
-        if (box.end_date) dateStr = `${dateStr} - ${box.end_date}`
+    const boxes = (this.holding.checkInCards || [])
+      .map((box, index) => {
+        // Create coverage string
+        let coverage = ''
+        // Get any enumeration associated with this box
+        if (box.enumeration.enumeration) coverage = box.enumeration.enumeration
+        let dateStr
+        if (box.start_date || box.end_date) {
+          if (box.start_date) dateStr = box.start_date
+          if (box.end_date) dateStr = `${dateStr} - ${box.end_date}`
 
-        if (coverage.length > 0) coverage = `${coverage} (${dateStr})`
-        else coverage = dateStr
-      }
-      const shelfMark = this.shelfMark() ? this.shelfMark() : null
-      const serialization = {
-        shelfMark,
-        coverage,
-        position: box.box_count,
-        status: box.status.label,
-        type: 'nypl:CheckInBox'
-      }
-      if (box.copy_count) {
-        serialization.copies = box.copy_count
-      }
-      return serialization
-    })
+          if (coverage.length > 0) coverage = `${coverage} (${dateStr})`
+          else coverage = dateStr
+        }
+        const shelfMark = this.shelfMark() ? this.shelfMark() : null
+        const serialization = {
+          shelfMark,
+          coverage,
+          position: box.box_count,
+          status: box.status.label,
+          type: 'nypl:CheckInBox'
+        }
+        if (box.copy_count) {
+          serialization.copies = box.copy_count
+        }
+        return serialization
+      })
       // Sort checkin boxes by box number:
       .sort((box1, box2) => box1.position - box2.position)
+
+    return boxes.length ? boxes : null
   }
 
   format () {
@@ -76,7 +78,7 @@ class EsHolding extends EsBase {
   // Only present in legacy fields
   // Some n fieldTag fields may be 843 Format fields, but will be ignored here as they are improperly formatted
   // to be retrieved via the fieldTag method
-  note () {
+  notes () {
     const notes = this.holding.fieldTag('n')
     if (notes && notes.length) {
       return notes.map((n) => n.value)

--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -74,8 +74,9 @@ class EsItem extends EsBase {
   }
 
   enumerationChronology () {
-    if (this.item.fieldTag('v') && this.item.fieldTag('v').length) {
-      return [this.item.fieldTag('v')[0].value]
+    const fieldTagVs = this.item.fieldTag('v')
+    if (fieldTagVs.length && fieldTagVs[0].value) {
+      return [fieldTagVs[0].value]
     }
 
     return null
@@ -235,10 +236,10 @@ class EsItem extends EsBase {
     // If not found in var field
     if (callnum) {
       // Pull callnumber suffix from fieldTag v if present
-      const callnumSuffix = this.item.fieldTag('v')
+      const callnumSuffix = this.item.fieldTag('v')[0]?.value
 
-      if (callnumSuffix && callnumSuffix.length) {
-        callnum += ' ' + callnumSuffix[0].value
+      if (callnumSuffix) {
+        callnum += ' ' + callnumSuffix
       }
 
       // Finally store the complete shelfMark data
@@ -318,7 +319,7 @@ class EsItem extends EsBase {
     if (item.isPartnerRecord()) {
       let message = item.varField('876', ['h'])
       if (message && message.length > 0) {
-        message = message.pop()
+        message = message.pop()?.value
 
         // If 876 $h is 'IN LIBRARY USE' or [blank]:
         if (message.toLowerCase() === 'in library use' || message.toLowerCase() === '') {
@@ -397,7 +398,7 @@ class EsItem extends EsBase {
       this.location = { id: holdingLocationId, label: holdingLocationLabel, rawId: location }
     } else if (location) {
       // If it's an NYPL item, the extracted location should exist in our sierraLocationMapping, so warn:
-      if (item.isNyplRecord()) logger.warn('Location id not recognize: ', location)
+      if (item.isNyplRecord()) logger.warn(`Location id not recognized for item ${this.item.id}: '${location}'`)
     }
 
     return this.location

--- a/lib/mappings/mappings.js
+++ b/lib/mappings/mappings.js
@@ -26,13 +26,13 @@ const amendMappingsBasedOnNyplSource = (data, nyplSource) => {
  * into SierraBase.varFieldsMulti
  */
 const mappingEntryToMarcQueryObject = (mapping) => {
-  const { marc, subfields } = mapping
-  const mappingOptions = { excludedSubfields: mapping.excludedSubfields }
-  return {
-    marc,
-    subfields,
-    mappingOptions
+  const marcQuery = Object.assign({}, mapping)
+  if (mapping.excludedSubfields) {
+    marcQuery.mappingOptions = { excludedSubfields: marcQuery.excludedSubfields }
+    delete marcQuery.excludedSubfields
   }
+
+  return marcQuery
 }
 
 /**

--- a/lib/mappings/mappings.js
+++ b/lib/mappings/mappings.js
@@ -21,13 +21,41 @@ const amendMappingsBasedOnNyplSource = (data, nyplSource) => {
   }, {})
 }
 
+/**
+ * Given a raw mapping entry, returns a {MarcQuery} object suitable for passing
+ * into SierraBase.varFieldsMulti
+ */
+const mappingEntryToMarcQueryObject = (mapping) => {
+  const { marc, subfields } = mapping
+  const mappingOptions = { excludedSubfields: mapping.excludedSubfields }
+  return {
+    marc,
+    subfields,
+    mappingOptions
+  }
+}
+
+/**
+ *
+ *  @typedef MappingGetter
+ *  @type {function}
+ *  @param {string} propertyName - The property name to look up (e.g. contributorLiteral)
+ *  @param {SierraBase} record - The record we intend to query (which may determine the set of MarcQuery objects returned
+ *  @return {MarcQuery[]}
+ *
+ * Given a record type, returns a function that returns a MappingsGetter function
+ *
+ * @param {string} type - The record type. One of bib, item, or holding
+ * @return {MappingGetter}
+ */
 const makeMappingsGetter = (type) => {
   const mappings = require(`./${type}-mapping.json`)
   return (propertyName, record) => {
     let mappingsForRecord = mappings
     // If nyplSource given, trim mappings to agree with it:
     if (record.nyplSource) mappingsForRecord = amendMappingsBasedOnNyplSource(mappings, record.nyplSource)
-    return mappingsForRecord[propertyName].paths || []
+    return (mappingsForRecord[propertyName].paths || [])
+      .map(mappingEntryToMarcQueryObject)
   }
 }
 

--- a/lib/platform-api/client.js
+++ b/lib/platform-api/client.js
@@ -1,6 +1,4 @@
 const NYPLDataApiClient = require('@nypl/nypl-data-api-client')
-const logger = require('../logger'
-)
 const kms = require('../kms.js')
 
 let clientPromise = null
@@ -10,12 +8,6 @@ let clientPromise = null
  *
  */
 const client = async () => {
-  logger.info(`client config ${JSON.stringify({
-    key: process.env.NYPL_OAUTH_KEY?.length,
-    SECRET: process.env.NYPL_OAUTH_SECRET?.length,
-    URL: process.env.NYPL_OAUTH_URL?.length,
-    nypl_base: process.env.NYPL_API_BASE_URL?.length
-  }, null, 2)}`)
   // If there is no active (or resolved) decrypt call..
   if (!clientPromise) {
     // Fire off the set of decrypt calls we need and save a reference to them:

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -55,6 +55,36 @@ const getSchema = async (schemaName) => {
   }
 }
 
+const holdingById = async (id) => {
+  try {
+    const client = await platformApi.client()
+    const resp = await client.get(`holdings/${id}`)
+    if (resp) {
+      return resp
+    } else {
+      logger.warn(`Warning: holding not found: ${id}`)
+      return null
+    }
+  } catch (e) {
+    logger.error('PlatformApi#holdingById error:\n', e)
+  }
+}
+
+const itemById = async (nyplSource, id) => {
+  try {
+    const client = await platformApi.client()
+    const resp = await client.get(`items/${nyplSource}/${id}`)
+    if (isValidResponse(resp)) {
+      return resp.data
+    } else {
+      logger.warn(`Warning: item not found: ${nyplSource}/${id}`)
+      return null
+    }
+  } catch (e) {
+    logger.error('PlatformApi#itemById error:\n', e)
+  }
+}
+
 const bibById = async (nyplSource, id) => {
   try {
     const client = await platformApi.client()
@@ -122,7 +152,7 @@ const modelPrefetch = async (bibs) => {
     })
     itemsArray.forEach((_items, i) => {
       const bib = bibs[i]
-      logger.debug(`Fetched ${_items.length} item(s) for ${bib.nyplSource}/${bib.id}`)
+      logger.debug(`Fetched ${(_items || []).length} item(s) for ${bib.nyplSource}/${bib.id}`)
       bib._items = _items
     })
 
@@ -230,6 +260,8 @@ const _bibIdentifiersForItems = async (items) => {
 module.exports = {
   getSchema,
   bibById,
+  holdingById,
+  itemById,
   modelPrefetch,
   _itemsForOneBib,
   _holdingsForBibs,

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -385,6 +385,10 @@ class SierraBase {
     if (!tagAndNumber) return null
 
     let [tag, number] = tagAndNumber.split('-')
+
+    // This should never happen, but if $6 is malformed, return null:
+    if (!tag || !number) return null
+
     // Remove trailing non-numerics from number (e.g. "880-04." should produce "04")
     number = number.replace(/[^0-9]$/, '')
 

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -1,5 +1,5 @@
 const logger = require('../logger')
-const { dupeObjectsByHash, uniqueObjectsByHash } = require('../utils')
+const { uniqueObjectsByHash } = require('../utils')
 
 class SierraBase {
   constructor (obj) {
@@ -156,6 +156,16 @@ class SierraBase {
     return matches
   }
 
+  /**
+   *  Given an array of VarFieldMatch objects, returns a new array of matches
+   *  with dupes removed. A dupe entry is:
+   *   - An entry where there's another entry with an identical primary and
+   *     parallel value
+   *   - Orphaned parallel where there exists another entry with an identical
+   *     parallel that also has a primary value
+   *   - Orphaned primary where there exists another entry with an identical
+   *     primary that also has a parallel
+   */
   _uniqueVarFieldMatches (matches) {
     // Create a hash function, which will be used to determine equality of two
     // different maches. We consider two VarFieldMatches as being equal if
@@ -167,10 +177,7 @@ class SierraBase {
     unique = this._removeRedundantOrphans(unique)
 
     if (unique.length < matches.length) {
-      const dupes = dupeObjectsByHash(matches, hasher)
-        // Only show first entry in each set of dupes, since they're presumably identical:
-        .map((set) => set[0])
-      logger.debug(`Removed ${matches.length - unique.length} dupe VarFieldMatch entries`, dupes)
+      logger.debug(`Removed ${matches.length - unique.length} dupe VarFieldMatch entries`)
     }
 
     return unique

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -161,8 +161,10 @@ class SierraBase {
     // different maches. We consider two VarFieldMatches as being equal if
     // their primary and parallel values are equal:
     const hasher = (entry) => [entry.value, entry.parallel?.value].join('🎸')
+    let unique = uniqueObjectsByHash(matches, hasher)
 
-    const unique = uniqueObjectsByHash(matches, hasher)
+    // Also remove any orphans whose value matches non-orphans:
+    unique = this._removeRedundantOrphans(unique)
 
     if (unique.length < matches.length) {
       const dupes = dupeObjectsByHash(matches, hasher)
@@ -172,6 +174,47 @@ class SierraBase {
     }
 
     return unique
+  }
+
+  /**
+   *  Given an array of VarFieldMatch objects, removes any that are redundant
+   *  given the other entries. A match is considered redundant if:
+   *   - It's an orphaned parallel and there exists another entry with an
+   *     identical parallel that also has a primary value, or:
+   *   - It's an orphaned primary and there exists another entry with an
+   *     identical primary that also has a parallel, or:
+   *
+   *  For example, given this set of entries:
+   *   - value: v1
+   *     parallel:
+   *       value: v1 parallel
+   *   - parallel:
+   *       value: v1 parallel
+   *
+   *  .. This function should remove the second entry because it's redundant given the first entry.
+   */
+  _removeRedundantOrphans (matches) {
+    return matches.reduce((a, match) => {
+      // If it's an orphaned parallel
+      const isOrphanedParallel = !!(!match.value && match.parallel?.value)
+      const isOrphanedPrimary = !!(match.value && !match.parallel?.value)
+      const isRedundantOrphan = (isOrphanedParallel || isOrphanedPrimary) && !!matches.find((other) => {
+        // If an identical parallel value is associated with a primary value, remove the orphaned parallel:
+        if (isOrphanedParallel) {
+          return other.value && other.parallel?.value === match.parallel.value
+
+        // If an identical primary value is associated with a parallel value, the orphaned primary is redundant:
+        } else {
+          return other.parallel?.value && other.value === match.value
+        }
+      })
+
+      if (!isRedundantOrphan) {
+        a.push(match)
+      }
+
+      return a
+    }, [])
   }
 
   // Get marc field segment (e.g. varFieldSegment('008', [35, 37]) => 'eng')
@@ -201,12 +244,18 @@ class SierraBase {
    * @return {VarFieldMatch[]}
    */
   varFieldsMulti (marcObjects) {
-    return marcObjects
+    let matches = marcObjects
       .map(({ marc, subfields, mappingOptions }) => {
-        return this.varField(marc, subfields, mappingOptions)
+        const options = Object.assign({}, mappingOptions, { dedupe: false })
+        return this.varField(marc, subfields, options)
       })
       .flat()
       .filter((varField) => varField)
+
+    // De-dupe based on primary and parallel values:
+    matches = this._uniqueVarFieldMatches(matches)
+
+    return matches
   }
 
   isPartnerRecord () {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,6 +67,24 @@ const unique = (array) => {
   return Array.from(new Set(array))
 }
 
+/**
+ *  Given an array of plainobjects and a "hasher" function, returns a new
+ *  array of those objects that are dupes based on the hasher function. That
+ *  is, two objects are considered identical if the hasher function returns the
+ *  same value for them. When dupes are found, all of them are returned.
+ *
+ *  @param {object[]} objects - An array of plainobjects
+ *  @param {function} hasher - A function that takes a single argument and
+ *    returns a string value that uniquely identifies the object's content
+ *
+ *  For example:
+ *    dupeObjectsByHash([
+ *      { k1: 'foo' },
+ *      { k1: 'foo', k2: 'bar' },
+ *      { k1: 'some other value', k2: 'bar' }
+ *    ], (obj) => obj.k1)
+ *    => [ { k1: 'foo' }, { k1: 'foo', k2: 'bar' } ]
+ */
 const dupeObjectsByHash = (objects, hasher) => {
   return Object.values(
     objects
@@ -80,6 +98,24 @@ const dupeObjectsByHash = (objects, hasher) => {
     .filter((set) => set.length > 1)
 }
 
+/**
+ *  Given an array of plainobjects and a "hasher" function, returns a new
+ *  array of those objects that are unique based on the hasher function. That
+ *  is, two objects are considered identical if the hasher function returns the
+ *  same value for them. When multiple objects are found to be identical, only
+ *  the last of them is returned, incidentally.
+ *
+ *  @param {object[]} objects - An array of plainobjects
+ *  @param {function} hasher - A function that takes a single argument and
+ *    returns a string value that uniquely identifies the object's content
+ *
+ *  For example:
+ *    dupeObjectsByHash([
+ *      { k1: 'foo' },
+ *      { k1: 'foo', k2: 'bar' }
+ *    ], (obj) => obj.k1)
+ *    => [ { k1: 'foo', k2: 'bar' } ]
+ */
 const uniqueObjectsByHash = (objects, hasher) => {
   if (!hasher || typeof hasher !== 'function') throw new Error('uniqueObjectsByHash requires a hasher function')
 

--- a/lib/utils/m2-customer-codes.js
+++ b/lib/utils/m2-customer-codes.js
@@ -31,7 +31,6 @@ const attachM2CustomerCodesToBibs = async (bibs) => {
     bib._items = bib.items().map((item) => {
       if (barcodeToM2CustomerCode[item.barcode]) {
         item._m2CustomerCode = barcodeToM2CustomerCode[item.barcode]
-        console.log('Attached code: ', item._m2CustomerCode)
       }
       return item
     })

--- a/lib/utils/primary-and-parallel-values.js
+++ b/lib/utils/primary-and-parallel-values.js
@@ -3,13 +3,15 @@ const { removeTrailingElementsMatching } = require('../utils')
 const primaryValues = (varFieldMatchObjects) => {
   // Return an empty string when there is a varFieldMatchObject with
   // no value property. Probably something like an orphaned parallel value.
-  return varFieldMatchObjects.map((match) => match.value || '')
+  return removeTrailingEmpties(
+    varFieldMatchObjects.map((match) => match.value || '')
+  )
 }
 
 const parallelValues = (varFieldMatchObjects) => {
   const values = varFieldMatchObjects.map(parallelValue)
 
-  return removeTrailingElementsMatching(values, (v) => !v)
+  return removeTrailingEmpties(values)
 }
 
 const parallelValue = (varFieldMatch) => {
@@ -17,6 +19,10 @@ const parallelValue = (varFieldMatch) => {
 
   return (varFieldMatch.parallel.direction === 'rtl' ? '\u200F' : '') +
     varFieldMatch.parallel.value
+}
+
+const removeTrailingEmpties = (values) => {
+  return removeTrailingElementsMatching(values, (v) => !v)
 }
 
 module.exports = {

--- a/lib/utils/suppressBibs.js
+++ b/lib/utils/suppressBibs.js
@@ -3,7 +3,7 @@ const { client } = require('../elastic-search/client')
 const { uriForRecordIdentifier } = require('./uriForRecordIdentifier')
 
 const suppressBib = async (bib) => {
-  const bibUri = uriForRecordIdentifier(bib.nyplSource, bib.id, 'bib')
+  const bibUri = await uriForRecordIdentifier(bib.nyplSource, bib.id, 'bib')
 
   const elasticClient = await client()
   // Support a killswitch if something goes awry:

--- a/lib/utils/volume-parse.js
+++ b/lib/utils/volume-parse.js
@@ -3,6 +3,8 @@
  * two element array
  */
 exports.parseVolume = (fieldTagV) => {
+  if (!fieldTagV || typeof fieldTagV !== 'string') return null
+
   const regExp = [
     // Captured values are the numbers found after volume/vol/v, no, bd, and reel/r with or without periods
     // (?:^|\s|-) is a non-capturing group to ensure that we are not matching on parts of other words

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -54,7 +54,9 @@ const run = async () => {
   }
 
   if (type === 'bib') {
-    Promise.all([buildLocalEsDocFromUri(nyplSource, id), currentDocument(argv.uri, indexName)])
+    const current = currentDocument(argv.uri, indexName)
+      .catch((e) => null)
+    Promise.all([buildLocalEsDocFromUri(nyplSource, id), current])
       .then(([{ recordsToIndex, recordsToDelete }, liveEsRecord]) => {
         if (recordsToDelete.length) {
           console.log('Indexer would delete this bib', recordsToDelete)
@@ -67,7 +69,11 @@ const run = async () => {
             console.log(JSON.stringify(localEsRecord, null, 2))
           }
 
-          printDiff(liveEsRecord, localEsRecord, argv.verbose)
+          if (liveEsRecord) {
+            printDiff(liveEsRecord, localEsRecord, argv.verbose)
+          } else {
+            console.log('Can\'t display diff because record doesn\'t exist in live index')
+          }
         }
       }).catch(e => {
         console.error(`Compare-With-Indexed encountered an error: ${e.message}`)

--- a/test/unit/elastic-search-requests.test.js
+++ b/test/unit/elastic-search-requests.test.js
@@ -10,13 +10,20 @@ const logger = require('../../lib/logger')
 describe('elastic search requests', () => {
   let bulkSpy
   let dateStub
+  let records
+
   before(() => {
     dateStub = sinon.stub(Date, 'now').returns('11:11pm')
   })
+
   after(() => {
     dateStub.restore()
   })
-  const records = [12345, 23456, 34567].map((uri) => ({ uri, _type: 'resource', _parent: 'mom', otherMetadata: 'meep morp' }))
+
+  beforeEach(() => {
+    records = [12345, 23456, 34567].map((uri) => ({ uri, _type: 'resource', _parent: 'mom', otherMetadata: 'meep morp' }))
+  })
+
   describe('_indexGeneric', () => {
     before(() => {
       bulkSpy = sinon.stub().callsFake((body) => Promise.resolve(body))
@@ -26,6 +33,7 @@ describe('elastic search requests', () => {
     after(() => {
       esClient.client.restore()
     })
+
     it('builds index statements - update', async () => {
       await esRequests.internal._indexGeneric('indexName', records, true)
 
@@ -74,7 +82,7 @@ describe('elastic search requests', () => {
         await esRequests.writeRecords(records)
       } catch (e) {}
 
-      expect(loggerSpy.calledWith('Indexing error: ya: messed up')).to.eq(true)
+      expect(loggerSpy.calledWith('Indexing error: Error updating 12345: ya: messed up')).to.eq(true)
     })
   })
 })

--- a/test/unit/es-holding.test.js
+++ b/test/unit/es-holding.test.js
@@ -78,7 +78,7 @@ describe('EsHolding model', () => {
     })
   })
 
-  describe('note', () => {
+  describe('notes', () => {
     it('returns notes array', () => {
       const holding = new EsHolding(new SierraHolding({
         varFields: [{
@@ -98,7 +98,7 @@ describe('EsHolding model', () => {
           subfields: null
         }]
       }))
-      expect(holding.note()).to.deep.equal(['Checkin **EDITION SPECIALE** here.', 'IRREGULAR'])
+      expect(holding.notes()).to.deep.equal(['Checkin **EDITION SPECIALE** here.', 'IRREGULAR'])
     })
   })
 

--- a/test/unit/primary-and-parallel-values.test.js
+++ b/test/unit/primary-and-parallel-values.test.js
@@ -23,15 +23,14 @@ describe('primary and parallel values', () => {
     })
     it('should return empty array for orphaned parallel with no .value', () => {
       const mappings = BibMappings.get('creatorLiteral', bib)
-      expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal([''])
+      expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal([])
     })
     it('orphaned parallel subfields and primary subfields with parallels', () => {
       // This bib has a single primary 200 with a linked parallel and one orphaned parallel:
       bib = new SierraBib(require('../fixtures/bib-parallels-chaos.json'))
       const mappings = [{ marc: '200', subfields: ['a', 'b'] }]
       expect(primaryValues(bib.varFieldsMulti(mappings))).to.deep.equal([
-        '200 primary value a 200 primary value b',
-        ''
+        '200 primary value a 200 primary value b'
       ])
     })
   })

--- a/test/unit/sierra-base.test.js
+++ b/test/unit/sierra-base.test.js
@@ -207,7 +207,8 @@ describe('SierraBase', function () {
               { tag: 'a', content: '$a content' }
             ]
           },
-          // This one has a parallel:
+          // This one has a parallel and identical primary content to the
+          // one above:
           {
             marcTag: '100',
             subfields: [
@@ -244,13 +245,15 @@ describe('SierraBase', function () {
         ]
       })
 
+      // Of the three possible hits, the first is invalidated because it's a
+      // redundant parallel next to the second. The last is invalidated because
+      // - although it differs in subfield content - the specific query used
+      // ignores the differing subfields, making it identical to the second hit
       const varField100 = record.varField(100, ['a'])
       expect(varField100).to.be.a('array')
-      expect(varField100).to.have.lengthOf(2)
+      expect(varField100).to.have.lengthOf(1)
       expect(varField100[0].value).to.equal('$a content')
-      expect(varField100[0].parallel).to.be.a('undefined')
-      expect(varField100[1].value).to.equal('$a content')
-      expect(varField100[1].parallel.value).to.equal('$a parallel content')
+      expect(varField100[0].parallel.value).to.equal('$a parallel content')
     })
   })
 

--- a/test/unit/sierra-base.test.js
+++ b/test/unit/sierra-base.test.js
@@ -276,4 +276,67 @@ describe('SierraBase', function () {
       ])
     })
   })
+
+  describe('_removeRedundantOrphans', () => {
+    it('de-dupes redundant orphaned parallels', () => {
+      let matches = [
+        { value: 'v1' },
+        {
+          value: 'v2',
+          parallel: {
+            value: 'v2 parallel'
+          }
+        },
+        // We expect this one to be removed because it's redundant next to the one above:
+        { parallel: { value: 'v2 parallel' } }
+      ]
+      expect(SierraBase.prototype._uniqueVarFieldMatches(matches)).to.deep.equal(matches.slice(0, 2))
+
+      matches = [
+        // We expect this one to be removed because it's redundant given the last one:
+        { value: 'v1' },
+        {
+          value: 'v2',
+          parallel: {
+            value: 'v2 parallel'
+          }
+        },
+        { value: 'v1', parallel: { value: 'v1 parallel' } }
+      ]
+      expect(SierraBase.prototype._removeRedundantOrphans(matches)).to.deep.equal(matches.slice(1, 3))
+    })
+  })
+
+  describe('_uniqueVarFieldMatches', () => {
+    it('de-dupes matches with identical primary and parallel values', () => {
+      const matches = [
+        { value: 'v1' },
+        {
+          value: 'v2',
+          parallel: {
+            value: 'v2 parallel'
+          }
+        },
+        // We expect these next two to be removed because they exactly match
+        // the first two:
+        { value: 'v1' },
+        {
+          value: 'v2',
+          parallel: {
+            value: 'v2 parallel'
+          }
+        }
+      ]
+      expect(SierraBase.prototype._uniqueVarFieldMatches(matches)).to.deep.equal(matches.slice(0, 2))
+
+      // Add a redundant orphan:
+      matches.push({
+        parallel: {
+          value: 'v2 parallel'
+        }
+      })
+      // Should remove redundant orphan:
+      expect(SierraBase.prototype._uniqueVarFieldMatches(matches)).to.deep.equal(matches.slice(0, 2))
+    })
+  })
 })


### PR DESCRIPTION
## 1. Better deduping of VarFieldMatches

 - We now dedupe VarFieldMatch objects returned from
   SierraBase.varFieldsMulti calls (previously only applied to
   individual SierraBase.varField calls)
 - The de-duping goes to extra effort to identify and remove any
   orphaned parallel that is redundant because another
   VarFieldMatch entry exists with that same value that is also attached
   to a primary value. (Also makes same check for orphaned primaries.

## 2. Fix bug with `excludedSubfields` in mappings

Fixes handling excludedSubfields property of mappings by ensuring that
mapping entries are cast into the proper MarcQuery structure (i.e. put
excludedSubfields into a mappingOptions hash). This bug was causing, for
example, contributorLiteral mappings to add $0 to values because the
excludedSubfields option was being ignored.