### PR TITLE
Additional cleanup

### DIFF
--- a/lib/elastic-search/requests.js
+++ b/lib/elastic-search/requests.js
@@ -41,7 +41,15 @@ const writeRecords = async (records) => {
     const errors = resp.items?.map((item) => item.index?.error)
     let message = 'Unknown error'
     if (errors) {
-      message = errors.map((error) => `${error.type}: ${error.reason}`)
+      message = errors
+        .map((error, i) => {
+          const record = records[i]
+          if (error) {
+            const record = records[i]
+            return `  Error updating ${record.uri}: ` + (error.type ? `${error.type}: ${error.reason}` : error) + ` (record ${record.uri})`
+          }
+        })
+        .filter((e) => e)
         .join('; ')
     }
     logger.error(`Indexing error: ${message}`)

--- a/lib/elastic-search/requests.js
+++ b/lib/elastic-search/requests.js
@@ -43,11 +43,11 @@ const writeRecords = async (records) => {
     if (errors) {
       message = errors
         .map((error, i) => {
-          const record = records[i]
           if (error) {
             const record = records[i]
-            return `  Error updating ${record.uri}: ` + (error.type ? `${error.type}: ${error.reason}` : error) + ` (record ${record.uri})`
+            return `Error updating ${record.uri}: ` + (error.type ? `${error.type}: ${error.reason}` : error)
           }
+          return null
         })
         .filter((e) => e)
         .join('; ')

--- a/lib/es-models/base.js
+++ b/lib/es-models/base.js
@@ -18,15 +18,16 @@ class EsBase {
     if (!this.shelfMark) return null
 
     const shelfMarkArray = this.shelfMark()
-    if (!shelfMarkArray) return null
+    if (!shelfMarkArray || !shelfMarkArray[0]) {
+      // Order by id if we have no call numbers, but make sure these items
+      // go after items with call numbers
+      return 'b' + this.uri()
+    }
+
     const shelfMark = shelfMarkArray.shift()
     if (shelfMark) {
       // order by call number; Put these items first
       return 'a' + sortableShelfMark(this.shelfMark()[0])
-    } else {
-      // Order by id if we have no call numbers, but make sure these items
-      // go after items with call numbers
-      return 'b' + this.uri()
     }
   }
 
@@ -60,6 +61,12 @@ class EsBase {
   }
 
   _valueToIndexFromBasicMapping (field, primary = true) {
+    const fields = this._varFieldMatchesForBasicMapping(field)
+    const values = primary ? primaryValues(fields) : parallelValues(fields)
+    return values.length === 0 ? null : values.map(trimTrailingPunctuation)
+  }
+
+  _varFieldMatchesForBasicMapping (field) {
     // due to implcit binding, `this` refers to the object where this method is called, which is an Elastic Search model (bib, item, or holding)
     const esRecordType = this.constructor.name
     let mapping
@@ -77,9 +84,7 @@ class EsBase {
       record = 'bib'
     }
     const mappings = mapping.get(field, this[record])
-    const fields = this[record].varFieldsMulti(mappings)
-    const values = primary ? primaryValues(fields) : parallelValues(fields)
-    return values.length === 0 ? null : values.map(trimTrailingPunctuation)
+    return this[record].varFieldsMulti(mappings)
   }
 }
 

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -729,7 +729,8 @@ class EsBib extends EsBase {
     identifiers = identifiers.concat(
       this.bib.varFieldsMulti(
         BibMappings.get('isbnCanceledInvalid', this.bib)
-      ) .filter((match) => match.value)
+      )
+        .filter((match) => match.value)
         .map((match) => {
           return { value: match.value, type: 'bf:Isbn', identifierStatus: 'canceled/invalid' }
         })

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -215,7 +215,8 @@ class EsBib extends EsBase {
   }
 
   idLccn () {
-    return this._valueToIndexFromBasicMapping('lccn')
+    const lccns = this._valueToIndexFromBasicMapping('lccn')
+    return lccns ? lccns.map((v) => v.trim()) : null
   }
 
   idOclc () {
@@ -247,7 +248,8 @@ class EsBib extends EsBase {
       oclcs = oclcs.concat(newOclcs)
     })
 
-    return unique(oclcs)
+    oclcs = unique(oclcs)
+    return oclcs.length ? oclcs : null
   }
 
   issuance () {
@@ -274,7 +276,7 @@ class EsBib extends EsBase {
   }
 
   language () {
-    return this._languageCodes()
+    const languageEntities = this._languageCodes()
       // Add lang label from lookup
       .map((code) => {
         const label = lookup('lookup-language-code-to-label')[code] || ''
@@ -283,6 +285,7 @@ class EsBib extends EsBase {
           label
         }
       })
+    return languageEntities.length ? languageEntities : null
   }
 
   language_packed () {

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -729,9 +729,10 @@ class EsBib extends EsBase {
     identifiers = identifiers.concat(
       this.bib.varFieldsMulti(
         BibMappings.get('isbnCanceledInvalid', this.bib)
-      ).map((value) => {
-        return { value, type: 'bf:Isbn', identifierStatus: 'canceled/invalid' }
-      })
+      ) .filter((match) => match.value)
+        .map((match) => {
+          return { value: match.value, type: 'bf:Isbn', identifierStatus: 'canceled/invalid' }
+        })
     )
 
     // Add OCLC(s):
@@ -759,9 +760,11 @@ class EsBib extends EsBase {
     identifiers = identifiers.concat(
       this.bib.varFieldsMulti(
         BibMappings.get('issnCanceled', this.bib)
-      ).map((value) => {
-        return { value, type: 'bf:Issn', identifierStatus: 'canceled' }
-      })
+      )
+        .filter((match) => match.value)
+        .map((match) => {
+          return { value: match.value, type: 'bf:Issn', identifierStatus: 'canceled' }
+        })
     )
 
     // Add incorrect ISSNs:

--- a/lib/es-models/checkin-card-item.js
+++ b/lib/es-models/checkin-card-item.js
@@ -145,11 +145,15 @@ class EsCheckinCardItem extends EsBase {
    */
   shelfMark () {
     const mappings = HoldingMappings.get('shelfMark', this.sierraHolding)
-    return this.sierraHolding.varFieldsMulti(mappings)
+    let shelfMarks = this.sierraHolding.varFieldsMulti(mappings)
       .map((varFieldMatch) => {
         // Sierra seems to put these '|h' prefixes on callnumbers; strip 'em
         return varFieldMatch.value.replace(/^\|h/, '')
       })
+    if (shelfMarks.length === 0 && this.esBib) {
+      shelfMarks = this.esBib.shelfMark()
+    }
+    return shelfMarks.length ? shelfMarks : null
   }
 
   shelfMark_sort () {

--- a/lib/es-models/holding.js
+++ b/lib/es-models/holding.js
@@ -76,7 +76,7 @@ class EsHolding extends EsBase {
   // Only present in legacy fields
   // Some n fieldTag fields may be 843 Format fields, but will be ignored here as they are improperly formatted
   // to be retrieved via the fieldTag method
-  note () {
+  notes () {
     const notes = this.holding.fieldTag('n')
     if (notes && notes.length) {
       return notes.map((n) => n.value)

--- a/lib/es-models/holding.js
+++ b/lib/es-models/holding.js
@@ -10,35 +10,37 @@ class EsHolding extends EsBase {
   }
 
   checkInBoxes () {
-    const boxes = this.holding.checkInCards || []
-    return boxes.map((box, index) => {
-      // Create coverage string
-      let coverage = ''
-      // Get any enumeration associated with this box
-      if (box.enumeration.enumeration) coverage = box.enumeration.enumeration
-      let dateStr
-      if (box.start_date || box.end_date) {
-        if (box.start_date) dateStr = box.start_date
-        if (box.end_date) dateStr = `${dateStr} - ${box.end_date}`
+    const boxes = (this.holding.checkInCards || [])
+      .map((box, index) => {
+        // Create coverage string
+        let coverage = ''
+        // Get any enumeration associated with this box
+        if (box.enumeration.enumeration) coverage = box.enumeration.enumeration
+        let dateStr
+        if (box.start_date || box.end_date) {
+          if (box.start_date) dateStr = box.start_date
+          if (box.end_date) dateStr = `${dateStr} - ${box.end_date}`
 
-        if (coverage.length > 0) coverage = `${coverage} (${dateStr})`
-        else coverage = dateStr
-      }
-      const shelfMark = this.shelfMark() ? this.shelfMark() : null
-      const serialization = {
-        shelfMark,
-        coverage,
-        position: box.box_count,
-        status: box.status.label,
-        type: 'nypl:CheckInBox'
-      }
-      if (box.copy_count) {
-        serialization.copies = box.copy_count
-      }
-      return serialization
-    })
+          if (coverage.length > 0) coverage = `${coverage} (${dateStr})`
+          else coverage = dateStr
+        }
+        const shelfMark = this.shelfMark() ? this.shelfMark() : null
+        const serialization = {
+          shelfMark,
+          coverage,
+          position: box.box_count,
+          status: box.status.label,
+          type: 'nypl:CheckInBox'
+        }
+        if (box.copy_count) {
+          serialization.copies = box.copy_count
+        }
+        return serialization
+      })
       // Sort checkin boxes by box number:
       .sort((box1, box2) => box1.position - box2.position)
+
+    return boxes.length ? boxes : null
   }
 
   format () {

--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -74,8 +74,9 @@ class EsItem extends EsBase {
   }
 
   enumerationChronology () {
-    if (this.item.fieldTag('v') && this.item.fieldTag('v').length) {
-      return [this.item.fieldTag('v')[0].value]
+    const fieldTagVs = this.item.fieldTag('v')
+    if (fieldTagVs.length && fieldTagVs[0].value) {
+      return [fieldTagVs[0].value]
     }
 
     return null
@@ -235,10 +236,10 @@ class EsItem extends EsBase {
     // If not found in var field
     if (callnum) {
       // Pull callnumber suffix from fieldTag v if present
-      const callnumSuffix = this.item.fieldTag('v')
+      const callnumSuffix = this.item.fieldTag('v')[0]?.value
 
-      if (callnumSuffix && callnumSuffix.length) {
-        callnum += ' ' + callnumSuffix[0].value
+      if (callnumSuffix) {
+        callnum += ' ' + callnumSuffix
       }
 
       // Finally store the complete shelfMark data

--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -318,7 +318,7 @@ class EsItem extends EsBase {
     if (item.isPartnerRecord()) {
       let message = item.varField('876', ['h'])
       if (message && message.length > 0) {
-        message = message.pop()
+        message = message.pop()?.value
 
         // If 876 $h is 'IN LIBRARY USE' or [blank]:
         if (message.toLowerCase() === 'in library use' || message.toLowerCase() === '') {
@@ -397,7 +397,7 @@ class EsItem extends EsBase {
       this.location = { id: holdingLocationId, label: holdingLocationLabel, rawId: location }
     } else if (location) {
       // If it's an NYPL item, the extracted location should exist in our sierraLocationMapping, so warn:
-      if (item.isNyplRecord()) logger.warn('Location id not recognize: ', location)
+      if (item.isNyplRecord()) logger.warn(`Location id not recognized for item ${this.item.id}: '${location}'`)
     }
 
     return this.location

--- a/lib/platform-api/client.js
+++ b/lib/platform-api/client.js
@@ -1,6 +1,4 @@
 const NYPLDataApiClient = require('@nypl/nypl-data-api-client')
-const logger = require('../logger'
-)
 const kms = require('../kms.js')
 
 let clientPromise = null

--- a/lib/platform-api/client.js
+++ b/lib/platform-api/client.js
@@ -10,12 +10,6 @@ let clientPromise = null
  *
  */
 const client = async () => {
-  logger.info(`client config ${JSON.stringify({
-    key: process.env.NYPL_OAUTH_KEY?.length,
-    SECRET: process.env.NYPL_OAUTH_SECRET?.length,
-    URL: process.env.NYPL_OAUTH_URL?.length,
-    nypl_base: process.env.NYPL_API_BASE_URL?.length
-  }, null, 2)}`)
   // If there is no active (or resolved) decrypt call..
   if (!clientPromise) {
     // Fire off the set of decrypt calls we need and save a reference to them:

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -55,6 +55,36 @@ const getSchema = async (schemaName) => {
   }
 }
 
+const holdingById = async (id) => {
+  try {
+    const client = await platformApi.client()
+    const resp = await client.get(`holdings/${id}`)
+    if (resp) {
+      return resp
+    } else {
+      logger.warn(`Warning: holding not found: ${id}`)
+      return null
+    }
+  } catch (e) {
+    logger.error('PlatformApi#holdingById error:\n', e)
+  }
+}
+
+const itemById = async (nyplSource, id) => {
+  try {
+    const client = await platformApi.client()
+    const resp = await client.get(`items/${nyplSource}/${id}`)
+    if (isValidResponse(resp)) {
+      return resp.data
+    } else {
+      logger.warn(`Warning: item not found: ${nyplSource}/${id}`)
+      return null
+    }
+  } catch (e) {
+    logger.error('PlatformApi#itemById error:\n', e)
+  }
+}
+
 const bibById = async (nyplSource, id) => {
   try {
     const client = await platformApi.client()
@@ -230,6 +260,8 @@ const _bibIdentifiersForItems = async (items) => {
 module.exports = {
   getSchema,
   bibById,
+  holdingById,
+  itemById,
   modelPrefetch,
   _itemsForOneBib,
   _holdingsForBibs,

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -122,7 +122,7 @@ const modelPrefetch = async (bibs) => {
     })
     itemsArray.forEach((_items, i) => {
       const bib = bibs[i]
-      logger.debug(`Fetched ${_items.length} item(s) for ${bib.nyplSource}/${bib.id}`)
+      logger.debug(`Fetched ${(_items || []).length} item(s) for ${bib.nyplSource}/${bib.id}`)
       bib._items = _items
     })
 

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -385,6 +385,10 @@ class SierraBase {
     if (!tagAndNumber) return null
 
     let [tag, number] = tagAndNumber.split('-')
+
+    // This should never happen, but if $6 is malformed, return null:
+    if (!tag || !number) return null
+
     // Remove trailing non-numerics from number (e.g. "880-04." should produce "04")
     number = number.replace(/[^0-9]$/, '')
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,6 +67,24 @@ const unique = (array) => {
   return Array.from(new Set(array))
 }
 
+/**
+ *  Given an array of plainobjects and a "hasher" function, returns a new
+ *  array of those objects that are dupes based on the hasher function. That
+ *  is, two objects are considered identical if the hasher function returns the
+ *  same value for them. When dupes are found, all of them are returned.
+ *
+ *  @param {object[]} objects - An array of plainobjects
+ *  @param {function} hasher - A function that takes a single argument and
+ *    returns a string value that uniquely identifies the object's content
+ *
+ *  For example:
+ *    dupeObjectsByHash([
+ *      { k1: 'foo' },
+ *      { k1: 'foo', k2: 'bar' },
+ *      { k1: 'some other value', k2: 'bar' }
+ *    ], (obj) => obj.k1)
+ *    => [ { k1: 'foo' }, { k1: 'foo', k2: 'bar' } ]
+ */
 const dupeObjectsByHash = (objects, hasher) => {
   return Object.values(
     objects
@@ -80,6 +98,24 @@ const dupeObjectsByHash = (objects, hasher) => {
     .filter((set) => set.length > 1)
 }
 
+/**
+ *  Given an array of plainobjects and a "hasher" function, returns a new
+ *  array of those objects that are unique based on the hasher function. That
+ *  is, two objects are considered identical if the hasher function returns the
+ *  same value for them. When multiple objects are found to be identical, only
+ *  the last of them is returned, incidentally.
+ *
+ *  @param {object[]} objects - An array of plainobjects
+ *  @param {function} hasher - A function that takes a single argument and
+ *    returns a string value that uniquely identifies the object's content
+ *
+ *  For example:
+ *    dupeObjectsByHash([
+ *      { k1: 'foo' },
+ *      { k1: 'foo', k2: 'bar' }
+ *    ], (obj) => obj.k1)
+ *    => [ { k1: 'foo', k2: 'bar' } ]
+ */
 const uniqueObjectsByHash = (objects, hasher) => {
   if (!hasher || typeof hasher !== 'function') throw new Error('uniqueObjectsByHash requires a hasher function')
 

--- a/lib/utils/m2-customer-codes.js
+++ b/lib/utils/m2-customer-codes.js
@@ -31,7 +31,6 @@ const attachM2CustomerCodesToBibs = async (bibs) => {
     bib._items = bib.items().map((item) => {
       if (barcodeToM2CustomerCode[item.barcode]) {
         item._m2CustomerCode = barcodeToM2CustomerCode[item.barcode]
-        console.log('Attached code: ', item._m2CustomerCode)
       }
       return item
     })

--- a/lib/utils/suppressBibs.js
+++ b/lib/utils/suppressBibs.js
@@ -3,7 +3,7 @@ const { client } = require('../elastic-search/client')
 const { uriForRecordIdentifier } = require('./uriForRecordIdentifier')
 
 const suppressBib = async (bib) => {
-  const bibUri = uriForRecordIdentifier(bib.nyplSource, bib.id, 'bib')
+  const bibUri = await uriForRecordIdentifier(bib.nyplSource, bib.id, 'bib')
 
   const elasticClient = await client()
   // Support a killswitch if something goes awry:

--- a/lib/utils/volume-parse.js
+++ b/lib/utils/volume-parse.js
@@ -3,6 +3,8 @@
  * two element array
  */
 exports.parseVolume = (fieldTagV) => {
+  if (!fieldTagV || typeof fieldTagV !== 'string') return null
+
   const regExp = [
     // Captured values are the numbers found after volume/vol/v, no, bd, and reel/r with or without periods
     // (?:^|\s|-) is a non-capturing group to ensure that we are not matching on parts of other words

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -54,7 +54,9 @@ const run = async () => {
   }
 
   if (type === 'bib') {
-    Promise.all([buildLocalEsDocFromUri(nyplSource, id), currentDocument(argv.uri, indexName)])
+    const current = currentDocument(argv.uri, indexName)
+      .catch((e) => null)
+    Promise.all([buildLocalEsDocFromUri(nyplSource, id), current])
       .then(([{ recordsToIndex, recordsToDelete }, liveEsRecord]) => {
         if (recordsToDelete.length) {
           console.log('Indexer would delete this bib', recordsToDelete)
@@ -67,7 +69,11 @@ const run = async () => {
             console.log(JSON.stringify(localEsRecord, null, 2))
           }
 
-          printDiff(liveEsRecord, localEsRecord, argv.verbose)
+          if (liveEsRecord) {
+            printDiff(liveEsRecord, localEsRecord, argv.verbose)
+          } else {
+            console.log('Can\'t display diff because record doesn\'t exist in live index')
+          }
         }
       }).catch(e => {
         console.error(`Compare-With-Indexed encountered an error: ${e.message}`)

--- a/test/unit/elastic-search-requests.test.js
+++ b/test/unit/elastic-search-requests.test.js
@@ -10,13 +10,20 @@ const logger = require('../../lib/logger')
 describe('elastic search requests', () => {
   let bulkSpy
   let dateStub
+  let records
+
   before(() => {
     dateStub = sinon.stub(Date, 'now').returns('11:11pm')
   })
+
   after(() => {
     dateStub.restore()
   })
-  const records = [12345, 23456, 34567].map((uri) => ({ uri, _type: 'resource', _parent: 'mom', otherMetadata: 'meep morp' }))
+
+  beforeEach(() => {
+    records = [12345, 23456, 34567].map((uri) => ({ uri, _type: 'resource', _parent: 'mom', otherMetadata: 'meep morp' }))
+  })
+
   describe('_indexGeneric', () => {
     before(() => {
       bulkSpy = sinon.stub().callsFake((body) => Promise.resolve(body))
@@ -26,6 +33,7 @@ describe('elastic search requests', () => {
     after(() => {
       esClient.client.restore()
     })
+
     it('builds index statements - update', async () => {
       await esRequests.internal._indexGeneric('indexName', records, true)
 
@@ -74,7 +82,7 @@ describe('elastic search requests', () => {
         await esRequests.writeRecords(records)
       } catch (e) {}
 
-      expect(loggerSpy.calledWith('Indexing error: ya: messed up')).to.eq(true)
+      expect(loggerSpy.calledWith('Indexing error: Error updating 12345: ya: messed up')).to.eq(true)
     })
   })
 })

--- a/test/unit/es-holding.test.js
+++ b/test/unit/es-holding.test.js
@@ -78,7 +78,7 @@ describe('EsHolding model', () => {
     })
   })
 
-  describe('note', () => {
+  describe('notes', () => {
     it('returns notes array', () => {
       const holding = new EsHolding(new SierraHolding({
         varFields: [{
@@ -98,7 +98,7 @@ describe('EsHolding model', () => {
           subfields: null
         }]
       }))
-      expect(holding.note()).to.deep.equal(['Checkin **EDITION SPECIALE** here.', 'IRREGULAR'])
+      expect(holding.notes()).to.deep.equal(['Checkin **EDITION SPECIALE** here.', 'IRREGULAR'])
     })
   })
 


### PR DESCRIPTION
 - Minor indexing fixes to:
   - EsHolding.notes
   - EsBib.identifierV2 (cancelled/invalid ISBN & ISSN)
 - Fix bug in suppressRecord
 - Better debug log messages in a few places
 - Better display of indexing errors when some but not all failed
 - In compare-with-indexed, don't fail hard if live document isn't found.