### PR TITLE
Change method for building Aeon URLs

### DIFF
--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -14,12 +14,13 @@ const { parseVolume } = require('../utils/volume-parse')
 const parseDate = require('../utils/item-date-parse')
 const { arrayToEsRangeObject, enumerationChronologySortFromEsRanges } = require('../utils/es-ranges')
 const { uriForRecordIdentifier } = require('../utils/uriForRecordIdentifier')
+const { aeonUrlForItem } = require('../utils/aeon-urls')
 
 class EsItem extends EsBase {
-  constructor (sierraItem, bib) {
+  constructor (sierraItem, esBib) {
     super(sierraItem)
     this.item = sierraItem
-    this.bib = bib
+    this.esBib = esBib
     this.location = null
   }
 
@@ -92,7 +93,7 @@ class EsItem extends EsBase {
   }
 
   formatLiteral () {
-    const bibMaterialType = this.bib.materialType()
+    const bibMaterialType = this.esBib.materialType()
     if (bibMaterialType && bibMaterialType.length) {
       return [bibMaterialType[0].label]
     }
@@ -181,15 +182,8 @@ class EsItem extends EsBase {
     return [statusRequestable && locationRequestable && accessMessageRequestable && typeRequestable]
   }
 
-  aeonUrl () {
-    if (!this.bib) return null
-    const baseAeonUrl = this.bib._aeonUrls()
-
-    if (!baseAeonUrl || !baseAeonUrl.length) return null
-
-    const aeonUrl = baseAeonUrl[0]
-      .replace(/Site=[^&]+/, 'Site=' + this._aeonSiteCode())
-
+  async aeonUrl () {
+    const aeonUrl = await aeonUrlForItem(this)
     return [aeonUrl]
   }
 
@@ -370,7 +364,7 @@ class EsItem extends EsBase {
     if (!callnum && item.varField('945', ['g']).length > 0) callnum = item.varField('945', ['g'])[0]
     // If not found, default to callnum from bib
     if (!callnum) {
-      const bibCallNum = this.bib && this.bib._callNum()
+      const bibCallNum = this.esBib && this.esBib._callNum()
       if (bibCallNum && bibCallNum.value) callnum = bibCallNum
     }
     // Sierra seems to put these '|h' prefixes on callnumbers; strip 'em

--- a/lib/scsb/requests.js
+++ b/lib/scsb/requests.js
@@ -1,6 +1,6 @@
 const scsb = require('./client')
 const logger = require('../logger')
-const { bNumberWithCheckDigit } = require('../utils')
+const { addSierraCheckDigit } = require('../utils')
 
 // Ensure scsb live querying has not been disabled via ENV:
 const scsbLiveQueryDisabled = process.env.DISABLE_SCSB_LIVE_QUERY === 'true'
@@ -15,7 +15,7 @@ const _createRecapCodeMap = async (bib) => {
     const client = await scsb.client()
     const __start = new Date()
     // Bib service returns bibId without check digit, but SCSB requires it, as well as .b prefix
-    const scsbFriendlyBibId = '.b' + bNumberWithCheckDigit(bib.id)
+    const scsbFriendlyBibId = '.b' + addSierraCheckDigit(bib.id)
     const updatedRecapBib = await client.search({ deleted: false, fieldValue: scsbFriendlyBibId, fieldName: 'OwningInstitutionBibId', owningInstitutions: ['NYPL'] })
     const elapsed = ((new Date()) - __start)
     logger.debug(`HTC searchByParam API took ${elapsed}ms`, { metric: 'searchByParam-owningInstitutionBibId', timeMs: elapsed })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,11 +2,23 @@ const isValidResponse = (resp) => {
   return resp && resp.data
 }
 
-const bNumberWithCheckDigit = (bnumber) => {
-  const ogBnumber = bnumber
+/**
+ *  Given a bnumber (numeric or prefixed) returns the same id suffixed with
+ *  Sierra's check digit
+ */
+const addSierraCheckDigit = (bnumber) => {
+  if (!bnumber) return null
+  if (typeof bnumber !== 'string') bnumber = String(bnumber)
+
+  const bnumberPattern = /^([a-z]*)(\d+)$/
+  if (!bnumberPattern.test(bnumber)) return null
+
+  // Strip prefix:
+  const [, prefix, ogBnumber] = bnumber.match(bnumberPattern)
+
   const results = []
   let multiplier = 2
-  for (const digit of bnumber.split('').reverse().join('')) {
+  for (const digit of ogBnumber.split('').reverse().join('')) {
     results.push(parseInt(digit) * multiplier++)
   }
 
@@ -18,7 +30,7 @@ const bNumberWithCheckDigit = (bnumber) => {
   if (remainder === 11) return `${ogBnumber}0`
   if (remainder === 10) return `${ogBnumber}x`
 
-  return `${ogBnumber}${remainder}`
+  return `${prefix}${ogBnumber}${remainder}`
 }
 
 /**
@@ -123,14 +135,24 @@ const uniqueObjectsByHash = (objects, hasher) => {
   return [...new Map(keyObjectPairs).values()]
 }
 
+/**
+ *  Given an array, returns the first value in the array. If the array is empty
+ *  or not an array, returns null.
+ */
+const firstValue = (array) => {
+  if (!Array.isArray(array) || array.length === 0) return null
+  return array[0]
+}
+
 module.exports = {
   isValidResponse,
-  bNumberWithCheckDigit,
+  addSierraCheckDigit,
   zeroPadString,
   leftPad,
   removeTrailingElementsMatching,
   trimTrailingPunctuation,
   unique,
   dupeObjectsByHash,
-  uniqueObjectsByHash
+  uniqueObjectsByHash,
+  firstValue
 }

--- a/lib/utils/aeon-urls.js
+++ b/lib/utils/aeon-urls.js
@@ -1,0 +1,65 @@
+const { firstValue, addSierraCheckDigit } = require('../utils')
+
+const LOCATION_LABEL_MAP = {
+  LPADN: 'ReCAP',
+  LPARF: 'LPA Reserve Film and Video Collection Special Collections material',
+  LPATF: 'Library for the Performing Arts Theatre on Film and Tape Archive',
+  LPATH: 'ReCAP',
+  SASBG: 'Schwarzman Rare Book Division',
+  SASBGSB: 'Berg Collection',
+  SASPF: 'Schwarzman Pforzheimer Collection',
+  SASRB: 'Schwarzman Rare Book Division',
+  SASMS: 'Schwarzman Manuscripts and Archives Division',
+  SCHMIRS: 'Schomburg Moving Images and Recorded Sound',
+  SCHRB: 'Schomburg Center'
+}
+
+const aeonUrlForItem = async (esItem) => {
+  if (!esItem._aeonSiteCode()) return null
+
+  const aeonBaseUrl = process.env.AEON_BASE_URL || 'https://specialcollections.nypl.org'
+  const catalogBaseUrl = process.env.CATALOG_BASE_URL || 'https://catalog.nypl.org/record='
+
+  const baseUrl = aeonBaseUrl + '/aeon/Aeon.dll?'
+
+  const bibUri = await esItem.esBib?.uri()
+  const itemUri = await esItem.uri()
+  const accessMessageLabel = (firstValue(esItem.accessMessage()) || {}).label
+  const sierraBib = esItem.item.bibs() && esItem.item.bibs().length ? esItem.item.bibs()[0] : null
+  const materialTypeLabel = sierraBib?.materialType?.value
+  // Get edition from 250 $a if it exists:
+  const edition = sierraBib?.varField('250', 'a')
+    .map((match) => match.value)
+    .pop()
+  const locationLabel = LOCATION_LABEL_MAP[esItem._aeonSiteCode()]
+
+  const props = {
+    Action: 10,
+    Form: 30,
+    Title: firstValue(esItem.esBib?.title()),
+    Site: esItem._aeonSiteCode(),
+    CallNumber: firstValue(esItem.shelfMark()) || '',
+    Author: firstValue(esItem.esBib?.creatorLiteral()) || '',
+    ItemPlace: firstValue(esItem.esBib?.placeOfPublication()) || '',
+    ItemPublisher: firstValue(esItem.esBib?.publisherLiteral()) || '',
+    Date: firstValue(esItem.esBib?.createdString()) || '',
+    ItemEdition: edition || '',
+    ItemInfo3: bibUri ? `${catalogBaseUrl}${bibUri}` : '',
+    ReferenceNumber: addSierraCheckDigit(bibUri),
+    ItemInfo1: accessMessageLabel || '',
+    ItemNumber: firstValue(esItem.idBarcode()) || '',
+    ItemISxN: addSierraCheckDigit(itemUri),
+    Genre: materialTypeLabel || '',
+    Location: locationLabel || ''
+  }
+  const nonEmptyProps = Object.keys(props).reduce((h, k) => {
+    if (props[k]) h[k] = props[k]
+    return h
+  }, {})
+
+  return baseUrl + new URLSearchParams(nonEmptyProps).toString()
+}
+
+module.exports = {
+  aeonUrlForItem
+}

--- a/test/fixtures/bib-22027953.json
+++ b/test/fixtures/bib-22027953.json
@@ -1,0 +1,1197 @@
+ {
+  "id": "22027953",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2023-05-04T01:31:33-04:00",
+  "createdDate": "2019-11-21T21:42:27-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "scb",
+      "name": "Schomburg Center - Moving Image & Recorded Sound"
+    },
+    {
+      "code": "scb",
+      "name": "Schomburg Center - Moving Image & Recorded Sound"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "eng",
+    "name": "English"
+  },
+  "title": "Documenting history in your own backyard : a symposium for archiving & preserving hip-hop culture",
+  "author": "",
+  "materialType": {
+    "code": "v  ",
+    "value": "DVD"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 2012,
+  "catalogDate": "2019-11-21",
+  "country": {
+    "code": "nyu",
+    "name": "New York (State)"
+  },
+  "normTitle": "documenting history in your own backyard a symposium for archiving and preserving hip hop culture",
+  "normAuthor": "",
+  "standardNumbers": [],
+  "controlNumber": "1128191166",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "eng",
+      "display": "English"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "scb  ",
+      "display": "Schomburg Center - Moving Image & Recorded Sound"
+    },
+    "27": {
+      "label": "",
+      "value": "7",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2019-11-21",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "v  ",
+      "display": "DVD"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "22027953",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2019-11-21T21:42:27Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2023-05-04T01:31:33Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "6",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "nyu",
+      "display": "New York (State)"
+    },
+    "98": {
+      "label": "",
+      "value": "2023-05-04T00:46:18Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Adler, B.,"
+        },
+        {
+          "tag": "e",
+          "content": "speaker."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Diaz, Martha,"
+        },
+        {
+          "tag": "e",
+          "content": "moderator."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Fullwood, Steven G.,"
+        },
+        {
+          "tag": "e",
+          "content": "speaker."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Gray, Paradise,"
+        },
+        {
+          "tag": "e",
+          "content": "speaker."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Muhammad, Khalil Gibran,"
+        },
+        {
+          "tag": "d",
+          "content": "1972-"
+        },
+        {
+          "tag": "e",
+          "content": "speaker."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Ortiz, Ben,"
+        },
+        {
+          "tag": "e",
+          "content": "speaker."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Richardson, Deborra A.,"
+        },
+        {
+          "tag": "e",
+          "content": "speaker."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Reagan, Katherine,"
+        },
+        {
+          "tag": "e",
+          "content": "speaker."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "710",
+      "ind1": "2",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Schomburg Center for Research in Black Culture."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Archives."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hip-hop"
+        },
+        {
+          "tag": "x",
+          "content": "Archival resources."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hip-hop"
+        },
+        {
+          "tag": "x",
+          "content": "Influence."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hip-hop"
+        },
+        {
+          "tag": "x",
+          "content": "History."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "650",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Hip-hop"
+        },
+        {
+          "tag": "x",
+          "content": "Social aspects"
+        },
+        {
+          "tag": "z",
+          "content": "United States."
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Nonfictions films."
+        },
+        {
+          "tag": "2",
+          "content": "lcgft"
+        }
+      ]
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": "655",
+      "ind1": " ",
+      "ind2": "7",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Panel discussions."
+        },
+        {
+          "tag": "2",
+          "content": "lcgft"
+        }
+      ]
+    },
+    {
+      "fieldTag": "e",
+      "marcTag": "257",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "United States."
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(OCoLC)1128191166"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "520",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "A symposium to discuss the preservation and documentation of the history of hip-hop culture at various archival institutions; what collectors and artists need to know about the archival process and the importance of moving artifacts into an institutional collection; tool kits available for collectors and archvists; building a community of archives and planning for the future."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Moderator, Martha Diaz (Hip Hop scholar, Schomburg Center).  Participants include: Bill Adler (author); Paradise Gray (author); Ben Ortiz (Cornell University); Katherine Reagan (Cornell University); Deborra A. Richardson (Smithsonian Institution)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "505",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Disc 1 (56 min.) Welcome (Dr. Kahil Gibran Muhammad and Stephen G. Fullwood, Schomburg Center).  Symposium Review and Introduction of Participants (Martha Diaz).  Preserving History in Institutional Archives: What Collectors/Creators Need to Know (Deborra Richardson) --  Disc 2 (53 min.)  An Example of an Institutional Collecting Model (Katherine Reagan and Ben Ortiz) -- Disc 3. (63 min.)  Private Collectors : Documenting and Preserving Hip Hop History (Bill Adler and Paradise Gray) -- Disc 4 (63 min.) Paradise Gray, (continued).  How to Document Your Community: a Tool Kit  (Deborra A. Richardson) -- Disc 5. How to Document Your community: a Tool Kit (continued).  Questions and Answers/General Discussion -- Disc 6 (62 min.) Questions and Answers/General Discussion (continued) -- Disc 7 (31 min.) Questions and Answers/General Discussion (continued).  Next Steps (Dr. Kahil Gibran Muhammad)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "518",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "o",
+          "content": "Symposium held"
+        },
+        {
+          "tag": "d",
+          "content": "October 19, 2012, at the"
+        },
+        {
+          "tag": "p",
+          "content": "Schomburg Center for Research in Black Culture."
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "1128191166",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "264",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "New York :"
+        },
+        {
+          "tag": "b",
+          "content": "Schomburg Center for Research in Black Culture,"
+        },
+        {
+          "tag": "c",
+          "content": "2012."
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "Sc Visual DVD-362"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "7 videodiscs (ca. 420 min.) :"
+        },
+        {
+          "tag": "b",
+          "content": "sound, color ;"
+        },
+        {
+          "tag": "c",
+          "content": "4 3/4 in."
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "336",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "two-dimensional moving image"
+        },
+        {
+          "tag": "2",
+          "content": "rdacontent"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "337",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "video"
+        },
+        {
+          "tag": "2",
+          "content": "rdamedia"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "338",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "videodisc"
+        },
+        {
+          "tag": "2",
+          "content": "rdacarrier"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "347",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "video file"
+        },
+        {
+          "tag": "b",
+          "content": "DVD video"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Documenting history in your own backyard :"
+        },
+        {
+          "tag": "b",
+          "content": "a symposium for archiving & preserving hip-hop culture /"
+        },
+        {
+          "tag": "c",
+          "content": "hosted by the Schomburg Center for Research in Black Culture."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "246",
+      "ind1": "3",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Symposium for archiving & preserving hip-hop culture"
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "246",
+      "ind1": "3",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Symposium for archiving and preserving hip-hop culture"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "856",
+      "ind1": "4",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "u",
+          "content": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Documenting+history+in+your+own+backyard+:+a+symposium+for+archiving+and+preserving+hip-hop+culture+/&Site=SCHMIRS&CallNumber=Sc+Visual+DVD-362&ItemInfo3=https://catalog.nypl.org/record=b22027953&ReferenceNumber=b220279536&Genre=DVD&Location=Schomburg+Moving+Images+and+Recorded+Sound"
+        },
+        {
+          "tag": "z",
+          "content": "Request Access to Schomburg Moving Images and Recorded Sound"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "003",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "OCoLC",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "007",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "vf cvahzs",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "191121e20121019nyu420            vleng dngmIi ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20191121044227.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "033",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "20121019"
+        },
+        {
+          "tag": "b",
+          "content": "3804"
+        },
+        {
+          "tag": "c",
+          "content": "N4"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NYP"
+        },
+        {
+          "tag": "b",
+          "content": "eng"
+        },
+        {
+          "tag": "e",
+          "content": "rda"
+        },
+        {
+          "tag": "c",
+          "content": "NYP"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "043",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "n-us---"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "049",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NYPP"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "MARS"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "901",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "JC"
+        },
+        {
+          "tag": "b",
+          "content": "SCL"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "946",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "m"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "Sc Visual DVD-362"
+        },
+        {
+          "tag": "c",
+          "content": "Disc 1"
+        },
+        {
+          "tag": "l",
+          "content": "SCBB2"
+        },
+        {
+          "tag": "h",
+          "content": "031"
+        },
+        {
+          "tag": "o",
+          "content": "1"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": "014"
+        },
+        {
+          "tag": "v",
+          "content": "SCL/JC"
+        },
+        {
+          "tag": "i",
+          "content": "33433092980592"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "Sc Visual DVD-362"
+        },
+        {
+          "tag": "c",
+          "content": "Disc 2"
+        },
+        {
+          "tag": "l",
+          "content": "SCBB2"
+        },
+        {
+          "tag": "h",
+          "content": "031"
+        },
+        {
+          "tag": "o",
+          "content": "1"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": "014"
+        },
+        {
+          "tag": "v",
+          "content": "SCL/JC"
+        },
+        {
+          "tag": "i",
+          "content": "33433092980584"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "Sc Visual DVD-362"
+        },
+        {
+          "tag": "c",
+          "content": "Disc 3"
+        },
+        {
+          "tag": "l",
+          "content": "SCBB2"
+        },
+        {
+          "tag": "h",
+          "content": "031"
+        },
+        {
+          "tag": "o",
+          "content": "1"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": "014"
+        },
+        {
+          "tag": "v",
+          "content": "SCL/JC"
+        },
+        {
+          "tag": "i",
+          "content": "33433092980576"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "Sc Visual DVD-362"
+        },
+        {
+          "tag": "c",
+          "content": "Disc 4"
+        },
+        {
+          "tag": "l",
+          "content": "SCBB2"
+        },
+        {
+          "tag": "h",
+          "content": "031"
+        },
+        {
+          "tag": "o",
+          "content": "1"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": "014"
+        },
+        {
+          "tag": "v",
+          "content": "SCL/JC"
+        },
+        {
+          "tag": "i",
+          "content": "33433092980568"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "Sc Visual DVD-362"
+        },
+        {
+          "tag": "c",
+          "content": "Disc 5"
+        },
+        {
+          "tag": "l",
+          "content": "SCBB2"
+        },
+        {
+          "tag": "h",
+          "content": "031"
+        },
+        {
+          "tag": "o",
+          "content": "1"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": "014"
+        },
+        {
+          "tag": "v",
+          "content": "SCL/JC"
+        },
+        {
+          "tag": "i",
+          "content": "33433092980550"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "Sc Visual DVD-362"
+        },
+        {
+          "tag": "c",
+          "content": "Disc 6"
+        },
+        {
+          "tag": "l",
+          "content": "SCBB2"
+        },
+        {
+          "tag": "h",
+          "content": "031"
+        },
+        {
+          "tag": "o",
+          "content": "1"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": "014"
+        },
+        {
+          "tag": "v",
+          "content": "SCL/JC"
+        },
+        {
+          "tag": "i",
+          "content": "33433092980543"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": "1",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "z",
+          "content": "8528"
+        },
+        {
+          "tag": "a",
+          "content": "Sc Visual DVD-362"
+        },
+        {
+          "tag": "c",
+          "content": "Disc 7"
+        },
+        {
+          "tag": "l",
+          "content": "SCBB2"
+        },
+        {
+          "tag": "h",
+          "content": "031"
+        },
+        {
+          "tag": "o",
+          "content": "1"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": "014"
+        },
+        {
+          "tag": "v",
+          "content": "SCL/JC"
+        },
+        {
+          "tag": "i",
+          "content": "33433092980535"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "910",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "RL"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000ngm a2200649Ii 4500",
+      "subfields": null
+    }
+  ]
+}

--- a/test/fixtures/item-37528709.json
+++ b/test/fixtures/item-37528709.json
@@ -1,0 +1,243 @@
+{
+  "nyplSource": "sierra-nypl",
+  "bibIds": [
+    "22027953"
+  ],
+  "id": "37528709",
+  "nyplType": "item",
+  "updatedDate": "2023-05-03T20:55:44-04:00",
+  "createdDate": "2019-11-21T21:42:27-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "scbb2",
+    "name": "Schomburg Center - Moving Image & Recorded Sound"
+  },
+  "status": {
+    "code": "-",
+    "display": "AVAILABLE",
+    "duedate": null
+  },
+  "barcode": "33433124443791",
+  "callNumber": "Sc Visual DVD-362",
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "",
+      "value": "false",
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": "1",
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": "0",
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": "-",
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "14",
+      "display": "moving image"
+    },
+    "62": {
+      "label": "Price",
+      "value": "0.000000",
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": "351",
+      "display": null
+    },
+    "68": {
+      "label": "Last Checkin",
+      "value": "2019-12-12T22:41:46Z",
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": "351",
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": "0",
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": "1",
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": "0",
+      "display": null
+    },
+    "78": {
+      "label": "Last Checkout Date",
+      "value": "2019-12-12T21:36:57Z",
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "scbb2",
+      "display": "Schomburg Center - Moving Image & Recorded Sound"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "37528709",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2019-11-21T21:42:27Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2023-05-03T20:55:44Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "7",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "-",
+      "display": "AVAILABLE"
+    },
+    "93": {
+      "label": "Inhouse Use",
+      "value": "0",
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": "0",
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": "-",
+      "display": null
+    },
+    "98": {
+      "label": "",
+      "value": "2021-07-29T20:28:10Z",
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "1",
+      "display": "USE IN LIBRARY"
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": "0",
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": "0",
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "31",
+      "display": "Schomburg"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": "0",
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": "0",
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": "6",
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": "false",
+      "display": null
+    },
+    "306": {
+      "label": "Sticky Status",
+      "value": "",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "33433124443791",
+      "subfields": null
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "Sc Visual DVD-362"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "SCL/JC",
+      "subfields": null
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "Disc 2",
+      "subfields": null
+    },
+    {
+      "fieldTag": "x",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "AEON eligible SCHMIRS",
+      "subfields": null
+    }
+  ]
+}

--- a/test/unit/utils-aeon-urls.test.js
+++ b/test/unit/utils-aeon-urls.test.js
@@ -1,0 +1,59 @@
+const expect = require('chai').expect
+const { parse: parseQueryString } = require('querystring')
+
+const { stubNyplSourceMapper } = require('./utils')
+
+const SierraItem = require('../../lib/sierra-models/item')
+const EsItem = require('../../lib/es-models/item')
+const SierraBib = require('../../lib/sierra-models/bib')
+const EsBib = require('../../lib/es-models/bib')
+
+const { aeonUrlForItem } = require('../../lib/utils/aeon-urls')
+
+describe('aeonn-urls', () => {
+  beforeEach(() => {
+    stubNyplSourceMapper()
+  })
+
+  it('returns nothing for item with no Aeon site code', async () => {
+    const record = new SierraItem(require('../fixtures/item-10003973.json'))
+    const esItem = new EsItem(record)
+    const url = await aeonUrlForItem(esItem)
+    expect(url).to.eq(null)
+  })
+
+  it('returns Aeon URL for item with a valid fieldTag x', async () => {
+    const record = new SierraItem(require('../fixtures/item-37528709.json'))
+    const esItem = new EsItem(record)
+
+    const url = await aeonUrlForItem(esItem)
+    // Note no esBib is associated, so fields are unnaturally light:
+    expect(url).to.eq('https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Site=SCHMIRS&CallNumber=Sc+Visual+DVD-362+Disc+2&ItemInfo1=Use+in+library&ItemNumber=33433124443791&ItemISxN=i375287097&Location=Schomburg+Moving+Images+and+Recorded+Sound')
+  })
+
+  it('returns Aeon URL with metadata fields pulled from bib', async () => {
+    const esBib = new EsBib(new SierraBib(require('../fixtures/bib-22027953.json')))
+    const esItem = new EsItem(new SierraItem(require('../fixtures/item-37528709.json')), esBib)
+
+    const url = await aeonUrlForItem(esItem)
+    const [baseUrl, queryString] = url.split('?')
+
+    expect(baseUrl).to.equal('https://specialcollections.nypl.org/aeon/Aeon.dll')
+    expect(parseQueryString(queryString)).to.deep.equal({
+      Action: '10',
+      CallNumber: 'Sc Visual DVD-362 Disc 2',
+      Date: '2012',
+      Form: '30',
+      Location: 'Schomburg Moving Images and Recorded Sound',
+      ItemInfo1: 'Use in library',
+      ItemInfo3: 'https://catalog.nypl.org/record=b22027953',
+      ItemISxN: 'i375287097',
+      ItemNumber: '33433124443791',
+      ItemPlace: 'New York',
+      ItemPublisher: 'Schomburg Center for Research in Black Culture',
+      ReferenceNumber: 'b220279536',
+      Site: 'SCHMIRS',
+      Title: 'Documenting history in your own backyard : a symposium for archiving & preserving hip-hop culture'
+    })
+  })
+})

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -67,4 +67,22 @@ describe('utils', () => {
       })
     })
   })
+
+  describe('addSierraCheckDigit', () => {
+    it('handles invalid inputs', () => {
+      expect(utils.addSierraCheckDigit(new Date())).to.equal(null)
+      expect(utils.addSierraCheckDigit('foo')).to.equal(null)
+    })
+
+    it('handles integers', () => {
+      expect(utils.addSierraCheckDigit(1234)).to.equal('12348')
+      expect(utils.addSierraCheckDigit(987654321)).to.equal('9876543210')
+    })
+
+    it('handles prefixed ids', () => {
+      expect(utils.addSierraCheckDigit('b1234')).to.equal('b12348')
+      expect(utils.addSierraCheckDigit('b987654321')).to.equal('b9876543210')
+      expect(utils.addSierraCheckDigit('cb987654321')).to.equal('cb9876543210')
+    })
+  })
 })

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,4 +1,5 @@
 const sinon = require('sinon')
+const nock = require('nock')
 
 const platformApi = require('../../lib/platform-api/client')
 
@@ -8,9 +9,34 @@ const errorGetStub = sinon.stub().throws()
 // This is a convenience function for stubbing the platformApi.
 const stubPlatformApiGetRequest = (get) => sinon.stub(platformApi, 'client').resolves({ get })
 
+const stubNyplSourceMapper = () => {
+  const response = {
+    'sierra-nypl': {
+      organization: 'nyplOrg:0001',
+      bibPrefix: 'b',
+      holdingPrefix: 'h',
+      itemPrefix: 'i'
+    },
+    'recap-pul': { organization: 'nyplOrg:0003', bibPrefix: 'pb', itemPrefix: 'pi' },
+    'recap-cul': { organization: 'nyplOrg:0002', bibPrefix: 'cb', itemPrefix: 'ci' },
+    'recap-hl': { organization: 'nyplOrg:0004', bibPrefix: 'hb', itemPrefix: 'hi' }
+  }
+
+  nock('https://raw.githubusercontent.com')
+    .defaultReplyHeaders({
+      'access-control-allow-origin': '*',
+      'access-control-allow-credentials': 'true'
+    })
+    .get('/NYPL/nypl-core/master/mappings/recap-discovery/nypl-source-mapping.json')
+    .reply(200, () => {
+      return response
+    })
+}
+
 module.exports = {
   genericGetStub,
   nullGetStub,
   errorGetStub,
-  stubPlatformApiGetRequest
+  stubPlatformApiGetRequest,
+  stubNyplSourceMapper
 }


### PR DESCRIPTION
No longer require or use bib 856 when building Aeon URLs. Build URL entirely from item and bib data when valid site code is found in item fieldTag x. This is the new way we'd like to build Aeon URLs. The Aeon URLs will differ from the existing 856 sourced URLs in (it is hoped) insignificant ways.

Also centralizes nypl-source-mapper stubbing since a lot of tests will trigger it.