### PR TITLE
Noref fix suppression of non research

### DIFF
--- a/lib/build-es-document.js
+++ b/lib/build-es-document.js
@@ -9,23 +9,21 @@ const {
 } = require('./prefilter')
 
 const buildEsDocument = async ({ type, records }) => {
-  // Dispatch based on what kind of event (Bib, Item, or Holding)
-  let recordsToDelete = []
-  switch (type) {
-    case 'Bib':
-      records = await filteredSierraBibsForBibs(records)
-      recordsToDelete = records.bibsToDelete
-      records = records.filteredBibs
-      break
-    case 'Item':
-      records = await filteredSierraItemsForItems(records)
-      records = await platformApi.bibsForHoldingsOrItems(type, records)
-      break
-    case 'Holding':
-      records = await filteredSierraHoldingsForHoldings(records)
-      records = await platformApi.bibsForHoldingsOrItems(type, records)
-      break
+  // If incoming event is Item/Holding, convert it into a Bib event:
+  if (type === 'Item') {
+    records = await filteredSierraItemsForItems(records)
+    records = await platformApi.bibsForHoldingsOrItems(type, records)
+  } else if (type === 'Holding') {
+    records = await filteredSierraHoldingsForHoldings(records)
+    records = await platformApi.bibsForHoldingsOrItems(type, records)
   }
+  // Now that `records` is Bibs, apply bib filtering:
+  const filtered = await filteredSierraBibsForBibs(records)
+  records = filtered.filteredBibs
+
+  // If original event was a 'Bib' event, mark the removed bibs for deletion:
+  const recordsToDelete = type === 'Bib' ? filtered.removedBibs : []
+
   // prefetch holdings and items and attach to bibs
   records = await platformApi.modelPrefetch(records)
   // instantiate sierra bibs with holdings and items attached.

--- a/lib/prefilter.js
+++ b/lib/prefilter.js
@@ -7,12 +7,23 @@ const filteredSierraBibsForBibs = (bibs) => {
   const bibsToDelete = []
   const filteredBibs = bibs
     .map(bib => new SierraBib(bib))
+    // Remove bibs that should be suppressed:
     .filter((bib) => {
-      const { suppress, rationale } = !bib.isResearch() ||
-        bib.getSuppressionWithRationale()
+      let suppress = false
 
+      // If bib is not Research, suppress it:
+      let { isResearch, rationale } = bib.getIsResearchWithRationale()
+      if (!isResearch) {
+        rationale = `is not Research (${rationale})`
+        suppress = true
+      } else {
+        // Is Research. Do suppression check:
+        ; ({ suppress, rationale } = bib.getSuppressionWithRationale())
+      }
+
+      // If suppressing the bib, log about it and add it to the bibsToDelete array:
       if (suppress) {
-        logger.debug(`Suppressing ${bib.id} because ${rationale}`)
+        logger.debug(`Suppressing ${bib.id} because ${rationale})`)
         bibsToDelete.push(bib)
       }
 

--- a/lib/prefilter.js
+++ b/lib/prefilter.js
@@ -4,39 +4,40 @@ const SierraHolding = require('./sierra-models/holding')
 const logger = require('./logger')
 
 const filteredSierraBibsForBibs = (bibs) => {
-  const bibsToDelete = []
+  const removedBibs = []
   const filteredBibs = bibs
     .map(bib => new SierraBib(bib))
     // Remove bibs that should be suppressed:
     .filter((bib) => {
-      let suppress = false
+      let suppressed = false
 
       // If bib is not Research, suppress it:
       let { isResearch, rationale } = bib.getIsResearchWithRationale()
       if (!isResearch) {
         rationale = `is not Research (${rationale})`
-        suppress = true
+        suppressed = true
       } else {
         // Is Research. Do suppression check:
-        ; ({ suppress, rationale } = bib.getSuppressionWithRationale())
+        ; ({ suppressed, rationale } = bib.getSuppressionWithRationale())
       }
 
-      // If suppressing the bib, log about it and add it to the bibsToDelete array:
-      if (suppress) {
+      // If suppressing the bib, log about it and add it to the removedBibs array:
+      if (suppressed) {
         logger.debug(`Suppressing ${bib.id} because ${rationale})`)
-        bibsToDelete.push(bib)
+        removedBibs.push(bib)
       }
 
-      return !suppress
+      return !suppressed
     })
 
-  return { filteredBibs, bibsToDelete }
+  return { filteredBibs, removedBibs }
 }
 
 const filteredSierraItemsForItems = (items) => {
   return items && items
     .map(item => new SierraItem(item))
-    .filter(item => !item.getSuppressionWithRationale().suppressed)
+    .filter((item) => !item.getSuppressionWithRationale().suppressed)
+    .filter((item) => item.isResearch())
 }
 
 const filteredSierraHoldingsForHoldings = (holdings) => {

--- a/lib/sierra-models/bib.js
+++ b/lib/sierra-models/bib.js
@@ -1,7 +1,11 @@
+
 const SierraItem = require('./item')
 const SierraHolding = require('./holding')
 const SierraBase = require('./base')
-const nyplCoreLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
+const {
+  locationHasExclusiveCollectionType,
+  locationHasResearchCenterPrefix
+} = require('../utils/locations')
 
 class SierraBib extends SierraBase {
   constructor (bib) {
@@ -40,9 +44,9 @@ class SierraBib extends SierraBase {
   }
 
   getSuppressionRationale () {
-    if (this.suppressed) return 'suppressed'
-    if (this.deleted) return 'deleted'
-    if (this.isOtfRecord()) return 'is-otf'
+    if (this.suppressed) return 'Suppressed'
+    if (this.deleted) return 'Deleted'
+    if (this.isOtfRecord()) return 'Is OTF'
     return null
   }
 
@@ -52,28 +56,44 @@ class SierraBib extends SierraBase {
   }
 
   getIsResearchWithRationale () {
-    let locationCodes = []
-    const locations = this.locations
-    if (locations && Array.isArray(locations)) {
-      locationCodes = locations.map(location => location.code)
+    // Partner bibs are Research
+    if (this.nyplSource && this.nyplSource !== 'sierra-nypl') {
+      return { isResearch: true, rationale: 'Is partner bib' }
     }
+
+    // Gather location codes on the bib:
+    const locationCodes = this.locations && Array.isArray(this.locations)
+      ? this.locations.map((location) => location.code)
+      : []
 
     if (locationCodes.includes('none') || locationCodes.includes('os')) {
       return { isResearch: true, rationale: 'Locations include none/os' }
+    } else {
+      // Determine locations that are exclusively 'Branch'
+      const branchLocations = locationCodes
+        .filter((code) => locationHasExclusiveCollectionType(code, 'Branch'))
+      // If bib has any locations with just "Branch" collection type, bib is not research:
+      if (branchLocations.length > 0) {
+        return {
+          isResearch: false,
+          rationale: `Has branch locations: ${branchLocations.join(', ')}`
+        }
+      }
     }
 
-    const hasResearchLocations = locationCodes.some((code) => {
-      const location = nyplCoreLocations[code] || {}
-      const isBranchLocation = (
-        Array.isArray(location.collectionTypes) &&
-        location.collectionTypes.length === 1 &&
-        location.collectionTypes[0] === 'Branch'
-      )
-      return !isBranchLocation
-    })
+    // Last ditch effort to determine is-research: If it has a location code
+    // that starts with a known research center location code prefix, assume
+    // it's Research (i.e. new location unknown to NYPL-Core):
+    if (locationCodes.some((code) => locationHasResearchCenterPrefix(code))) {
+      return {
+        isResearch: true,
+        rationale: `Has likely Research locations: ${locationCodes.join(', ')}`
+      }
+    }
+
     return {
-      isResearch: hasResearchLocations,
-      rationale: (hasResearchLocations ? 'Has' : 'Does not have') + ' research locations'
+      isResearch: false,
+      rationale: `Location codes do not imply Research: ${locationCodes.join(', ')}`
     }
   }
 

--- a/lib/sierra-models/bib.js
+++ b/lib/sierra-models/bib.js
@@ -51,7 +51,7 @@ class SierraBib extends SierraBase {
     return { suppressed: Boolean(rationale), rationale }
   }
 
-  isResearch () {
+  getIsResearchWithRationale () {
     let locationCodes = []
     const locations = this.locations
     if (locations && Array.isArray(locations)) {
@@ -59,15 +59,27 @@ class SierraBib extends SierraBase {
     }
 
     if (locationCodes.includes('none') || locationCodes.includes('os')) {
-      return true
+      return { isResearch: true, rationale: 'Locations include none/os' }
     }
 
-    return locationCodes.some((code) => {
+    const hasResearchLocations = locationCodes.some((code) => {
       const location = nyplCoreLocations[code] || {}
-      return !(Array.isArray(location.collectionTypes) &&
+      const isBranchLocation = (
+        Array.isArray(location.collectionTypes) &&
         location.collectionTypes.length === 1 &&
-        location.collectionTypes[0] === 'Branch')
+        location.collectionTypes[0] === 'Branch'
+      )
+      return !isBranchLocation
     })
+    return {
+      isResearch: hasResearchLocations,
+      rationale: (hasResearchLocations ? 'Has' : 'Does not have') + ' research locations'
+    }
+  }
+
+  isResearch () {
+    const { isResearch } = this.getIsResearchWithRationale()
+    return isResearch
   }
 }
 

--- a/lib/sierra-models/item.js
+++ b/lib/sierra-models/item.js
@@ -1,4 +1,12 @@
+const nyplCoreItemTypes = require('@nypl/nypl-core-objects')('by-catalog-item-type')
+
 const SierraBase = require('./base')
+const logger = require('../logger')
+const {
+  locationHasExclusiveCollectionType,
+  locationHasResearchCenterPrefix
+} = require('../utils/locations')
+
 class SierraItem extends SierraBase {
   constructor (item) {
     super(item)
@@ -29,6 +37,55 @@ class SierraItem extends SierraBase {
     if (this.isPartnerRecord()) type = 1
 
     return type
+  }
+
+  getIsResearchWithRationale () {
+    if (this.isPartnerRecord()) {
+      return { isResearch: true, rationale: 'Is partner record' }
+    }
+
+    // If object has location, see if location implies items are definitely Research or definitely Branch
+    if (this.location && this.location.code) {
+      if (locationHasExclusiveCollectionType(this.location.code, 'Research')) {
+        return { isResearch: true, rationale: 'Has research location' }
+      }
+    }
+
+    // If object has item type, does type imply item is Research?
+    const itemType = this.getItemType()
+    let itemTypeImpliesResearch = false
+    if (itemType) {
+      if (!nyplCoreItemTypes[itemType]) {
+        logger.warn(`Unrecognized itemType: ${itemType}`)
+      } else {
+        // The item's itype implies 'Research' if the itype collectionType includes 'Research'
+        const collectionTypes = nyplCoreItemTypes[itemType].collectionType
+        itemTypeImpliesResearch = collectionTypes && collectionTypes.indexOf('Research') >= 0
+      }
+    }
+    if (itemTypeImpliesResearch) {
+      return { isResearch: true, rationale: `Item type ${itemType} implies research` }
+    }
+
+    // Perform lowest quality check: Assume research if location starts with a
+    // known research center prefix:
+    if (this.location?.code && locationHasResearchCenterPrefix(this.location.code)) {
+      return {
+        isResearch: true,
+        rationale: `Has likely Research location: ${this.location.code}`
+      }
+    }
+
+    return {
+      isResearch: false,
+      rationale: `Location (${this.location?.code}) and Item Type (${itemType}) collectionTypes are not Research`
+    }
+  }
+
+  isResearch () {
+    const { isResearch, rationale } = this.getIsResearchWithRationale()
+    logger.debug(`Determined ${this.id} is ${isResearch ? '' : 'not '}research because: ${rationale}`)
+    return isResearch
   }
 
   getSuppressionRationale () {

--- a/lib/sierra-models/item.js
+++ b/lib/sierra-models/item.js
@@ -21,11 +21,21 @@ class SierraItem extends SierraBase {
     return this._bibs
   }
 
+  /**
+   *  Returns an object indicating whether this item is suppressed or not and why.
+   *
+   *  @return {object} An object with {boolean} `suppressed` and {string} `rationale`
+   */
   getSuppressionWithRationale () {
-    const rationale = this.getSuppressionRationale()
+    const rationale = this._suppressionRationale()
     return { suppressed: Boolean(rationale.length), rationale }
   }
 
+  /**
+   *  Returns item Item Type as an integer
+   *
+   *  @return {integer}
+   */
   getItemType () {
     let type = null
 
@@ -39,78 +49,136 @@ class SierraItem extends SierraBase {
     return type
   }
 
+  /**
+   *  Returns an object indicating whether this item is Research or not and why.
+   *
+   *  An item is Research if:
+   *   - It's a partner record
+   *   - Item location is tagged Research in NYPL-Core
+   *   - Item location is not in NYPL-Core, but location prefix begins with a known
+   *     Research center prefix (e.g. ma*, sc*)
+   *   - Item "Item Type" is tagged Research in NYPL-Core
+   *
+   *  @return {object} An object defining {boolean} `isResearch` and {string} `rationale`
+   */
   getIsResearchWithRationale () {
+    // If item is a partner record, it's necessarily Research
     if (this.isPartnerRecord()) {
       return { isResearch: true, rationale: 'Is partner record' }
     }
 
-    // If object has location, see if location implies items are definitely Research or definitely Branch
-    if (this.location && this.location.code) {
-      if (locationHasExclusiveCollectionType(this.location.code, 'Research')) {
-        return { isResearch: true, rationale: 'Has research location' }
-      }
+    // If location is tagged Research in NYPL-Core, item is Research:
+    if (this._locationIsResearch()) {
+      return { isResearch: true, rationale: 'Has research location' }
     }
 
-    // If object has item type, does type imply item is Research?
-    const itemType = this.getItemType()
-    let itemTypeImpliesResearch = false
-    if (itemType) {
-      if (!nyplCoreItemTypes[itemType]) {
-        logger.warn(`Unrecognized itemType: ${itemType}`)
-      } else {
-        // The item's itype implies 'Research' if the itype collectionType includes 'Research'
-        const collectionTypes = nyplCoreItemTypes[itemType].collectionType
-        itemTypeImpliesResearch = collectionTypes && collectionTypes.indexOf('Research') >= 0
-      }
-    }
-    if (itemTypeImpliesResearch) {
-      return { isResearch: true, rationale: `Item type ${itemType} implies research` }
-    }
-
-    // Perform lowest quality check: Assume research if location starts with a
-    // known research center prefix:
-    if (this.location?.code && locationHasResearchCenterPrefix(this.location.code)) {
+    // If location prefix matches known Research center prefixes, assume item
+    // is Research (i.e. new Research Sierra location):
+    if (this._locationHasResearchPrefix()) {
       return {
         isResearch: true,
         rationale: `Has likely Research location: ${this.location.code}`
       }
     }
 
+    // If has Item Type tagged Research in NYPL-Core, it's Research:
+    if (this._itemTypeIsResearch()) {
+      return { isResearch: true, rationale: `Item type ${this.getItemType()} implies research` }
+    }
+
     return {
       isResearch: false,
-      rationale: `Location (${this.location?.code}) and Item Type (${itemType}) collectionTypes are not Research`
+      rationale: `Location (${this.location?.code}) and Item Type (${this.getItemType()}) collectionTypes are not Research`
     }
   }
 
+  /**
+   *  Returns true if item is determined to be Research based on a number of
+   *  checks. (See getIsResearchWithRationale)
+   */
   isResearch () {
     const { isResearch, rationale } = this.getIsResearchWithRationale()
     logger.debug(`Determined ${this.id} is ${isResearch ? '' : 'not '}research because: ${rationale}`)
     return isResearch
   }
 
-  getSuppressionRationale () {
+  /**
+   *  Return true if Item Type is tagged Research in NYPL-Core, implying this
+   *  item is Research
+   */
+  _itemTypeIsResearch () {
+    // If object has item type, does NYPL-Core tag that type as Research?
+    const itemType = this.getItemType()
+    if (itemType) {
+      if (!nyplCoreItemTypes[itemType]) {
+        logger.warn(`Unrecognized itemType: ${itemType}`)
+      } else {
+        // The item's itype implies 'Research' if the itype collectionType includes 'Research'
+        const collectionTypes = nyplCoreItemTypes[itemType].collectionType
+        return collectionTypes && collectionTypes.indexOf('Research') >= 0
+      }
+    }
+  }
+
+  /**
+   *  Returns true if item location has a known Research center prefix (e.g.
+   *  ma, sc, pa). This check is important for items assigned to newly added
+   *  Research Sierra locations that don't yet exist in NYPL-Core. If an item
+   *  is added to ma1234 and NYPL-Core has not yet documented that new
+   *  location as having collectionType 'Research', we may still assume the
+   *  location is Research based on the 'ma' prefix. Doing so means items
+   *  assigned to that location become visible by default in RC.
+   */
+  _locationHasResearchPrefix () {
+    // Perform lowest quality check: Assume research if location starts with a
+    // known research center prefix:
+    return this.location?.code && locationHasResearchCenterPrefix(this.location.code)
+  }
+
+  /**
+   *  Returns true if location is tagged Research in NYPL-Core
+   */
+  _locationIsResearch () {
+    // If object has a location, see if NYPL-Core tags it as Research:
+    if (this.location?.code) {
+      return (locationHasExclusiveCollectionType(this.location.code, 'Research'))
+    }
+  }
+
+  /**
+   *  Returns a string[] representing the reason(s) for suppression if this
+   *  item is suppressed. Otherwise returns an empty []
+   *
+   *  An item should be considered suppressed if:
+   *   - Item is deleted
+   *   - Item is a partner record with an 876|x or 900|a of "Private"
+   *   - Item is an NYPL OTF record (i.e. Item Type 50)
+   *   - Item is an NYPL record with a restricted icode2
+   */
+  _suppressionRationale () {
     const rationale = []
-    if (this.deleted) rationale.push('deleted')
+    if (this.deleted) rationale.push('Deleted')
 
     if (this.isPartnerRecord()) {
       let group = this.varField('876', ['x'])
       if (group && group.length > 0 && group[0].value === 'Private') {
-        rationale.push('876 $x')
+        rationale.push('Partner 876 $x')
       }
 
       group = this.varField('900', ['a'])
       if (group && group.length > 0 && group[0].value === 'Private') {
-        rationale.push('900 $a')
+        rationale.push('Partner 900 $a')
       }
     } else {
       // First, we'll suppress it if catalogItemType is 50 (temporary item, aka
       // OTF record):
       if (this.getItemType() && this.getItemType() === 50) {
-        rationale.push('catalogItemType')
+        rationale.push('Item Type 50')
       }
       // Next, we'll suppress it if fixed "Item Code 2" is 's', 'w', 'd', or 'p'
-      if (['s', 'w', 'd', 'p'].indexOf(this.fixed('Item Code 2')) >= 0) {
-        rationale.push('fixed "Item Code 2"')
+      const icode2 = this.fixed('Item Code 2')
+      if (['s', 'w', 'd', 'p'].indexOf(icode2) >= 0) {
+        rationale.push('Restricted icode2')
       }
     }
 

--- a/lib/utils/locations.js
+++ b/lib/utils/locations.js
@@ -1,0 +1,30 @@
+const nyplCoreLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
+
+/**
+ *  Given a location id and a collectionType (Research / Branch), returns true
+ *  if that location has no other collectionTypes but the named collectionType
+ *  in NYPL-Core.
+ */
+const locationHasExclusiveCollectionType = (locationId, collectionType) => {
+  const mappedLocation = nyplCoreLocations[locationId]
+  // If collectionType has only one value, that imples item is definitely that type
+  if (mappedLocation && Array.isArray(mappedLocation.collectionTypes) && mappedLocation.collectionTypes.length === 1) {
+    return collectionType === mappedLocation.collectionTypes[0]
+  }
+
+  return false
+}
+
+/**
+ *  Given a location id (e.g. 'mal92', 'abcd12'), returns true if location id
+ *  has a known Research Center prefix (i.e. is likely SASB/Schomburg/LPA
+ *  Research)
+ */
+const locationHasResearchCenterPrefix = (locationId) => {
+  return /^(ma|sc|pa)/.test(locationId)
+}
+
+module.exports = {
+  locationHasExclusiveCollectionType,
+  locationHasResearchCenterPrefix
+}

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -48,41 +48,48 @@ const run = async () => {
   const mapper = (new NyplSourceMapper())
   const { id, type, nyplSource } = await mapper.splitIdentifier(argv.uri)
 
-  const buildLocalEsDocFromUri = async (nyplSource, id) => {
-    const bib = await bibById(nyplSource, id)
-    return buildEsDocument({ type: 'Bib', records: [bib] })
+  const buildLocalEsDocFromUri = async (type, nyplSource, id) => {
+    switch (type) {
+      case 'bib':
+        const bib = await bibById(nyplSource, id)
+        return buildEsDocument({ type: 'Bib', records: [bib] })
+      case 'item':
+        const item = await itemById(nyplSource, id)
+        return buildEsDocument({ type: 'Item', records: [item] })
+      case 'holding':
+        const holding = await holdingById(id)
+        return buildEsDocument({ type: 'Holding', records: [holding] })
+    }
   }
 
   if (type === 'bib') {
     const current = currentDocument(argv.uri, indexName)
       .catch((e) => null)
-    Promise.all([buildLocalEsDocFromUri(nyplSource, id), current])
-      .then(([{ recordsToIndex, recordsToDelete }, liveEsRecord]) => {
-        if (recordsToDelete.length) {
-          console.log('Indexer would delete this bib', recordsToDelete)
-        } else {
-          // The local ES record is the sole element in recordsToIndex
-          const localEsRecord = recordsToIndex[0]
-
-          if (argv.printDocument) {
-            console.log('Built document:\n_______________________________________________________')
-            console.log(JSON.stringify(localEsRecord, null, 2))
-          }
-
-          if (liveEsRecord) {
-            printDiff(liveEsRecord, localEsRecord, argv.verbose)
-          } else {
-            console.log('Can\'t display diff because record doesn\'t exist in live index')
-          }
-        }
-      }).catch(e => {
-        console.error(`Compare-With-Indexed encountered an error: ${e.message}`)
-        console.error(e.stack)
-        die()
-      })
-  } else {
-    die(`Only configured for bib uris, ${type} uri specified`)
   }
+  Promise.all([buildLocalEsDocFromUri(type, nyplSource, id), current])
+    .then(([{ recordsToIndex, recordsToDelete }, liveEsRecord]) => {
+      if (recordsToDelete.length) {
+        console.log('Indexer would delete this bib', recordsToDelete)
+      } else {
+        // The local ES record is the sole element in recordsToIndex
+        const localEsRecord = recordsToIndex[0]
+
+        if (argv.printDocument) {
+          console.log('Built document:\n_______________________________________________________')
+          console.log(JSON.stringify(localEsRecord, null, 2))
+        }
+
+        if (liveEsRecord) {
+          printDiff(liveEsRecord, localEsRecord, argv.verbose)
+        } else {
+          console.log('Can\'t display diff because record doesn\'t exist in live index')
+        }
+      }
+    }).catch(e => {
+      console.error(`Compare-With-Indexed encountered an error: ${e.message}`)
+      console.error(e.stack)
+      die()
+    })
 }
 
 run()

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -24,7 +24,7 @@ dotenv.config({ path: argv.envfile || './config/qa.env' })
 
 const NyplSourceMapper = require('../lib/utils/nypl-source-mapper')
 const { awsInit, die, printDiff } = require('./utils')
-const { bibById } = require('../lib/platform-api/requests')
+const { bibById, itemById, holdingById } = require('../lib/platform-api/requests')
 const { buildEsDocument } = require('../lib/build-es-document')
 const { currentDocument } = require('../lib/elastic-search/requests')
 
@@ -49,47 +49,46 @@ const run = async () => {
   const { id, type, nyplSource } = await mapper.splitIdentifier(argv.uri)
 
   const buildLocalEsDocFromUri = async (type, nyplSource, id) => {
-    switch (type) {
-      case 'bib':
-        const bib = await bibById(nyplSource, id)
-        return buildEsDocument({ type: 'Bib', records: [bib] })
-      case 'item':
-        const item = await itemById(nyplSource, id)
-        return buildEsDocument({ type: 'Item', records: [item] })
-      case 'holding':
-        const holding = await holdingById(id)
-        return buildEsDocument({ type: 'Holding', records: [holding] })
+    if (type === 'bib') {
+      const bib = await bibById(nyplSource, id)
+      return buildEsDocument({ type: 'Bib', records: [bib] })
+    } else if (type === 'item') {
+      const item = await itemById(nyplSource, id)
+      return buildEsDocument({ type: 'Item', records: [item] })
+    } else if (type === 'holding') {
+      const holding = await holdingById(id)
+      return buildEsDocument({ type: 'Holding', records: [holding] })
     }
   }
 
-  if (type === 'bib') {
-    const current = currentDocument(argv.uri, indexName)
-      .catch((e) => null)
-  }
-  Promise.all([buildLocalEsDocFromUri(type, nyplSource, id), current])
-    .then(([{ recordsToIndex, recordsToDelete }, liveEsRecord]) => {
-      if (recordsToDelete.length) {
-        console.log('Indexer would delete this bib', recordsToDelete)
-      } else {
-        // The local ES record is the sole element in recordsToIndex
-        const localEsRecord = recordsToIndex[0]
+  try {
+    const { recordsToIndex, recordsToDelete } = await buildLocalEsDocFromUri(type, nyplSource, id)
+    if (recordsToDelete.length) {
+      console.log('Indexer would delete this bib', recordsToDelete)
+    } else if (!recordsToIndex.length) {
+      console.log(`Indexer filtered out this ${type}`)
+    } else {
+      // The local ES record is the sole element in recordsToIndex
+      const localEsRecord = recordsToIndex[0]
+      const liveEsRecord = await currentDocument(localEsRecord.uri, indexName)
+        .catch((e) => console.log(`Could not find ${localEsRecord.uri} in ${indexName}`))
 
-        if (argv.printDocument) {
-          console.log('Built document:\n_______________________________________________________')
-          console.log(JSON.stringify(localEsRecord, null, 2))
-        }
-
-        if (liveEsRecord) {
-          printDiff(liveEsRecord, localEsRecord, argv.verbose)
-        } else {
-          console.log('Can\'t display diff because record doesn\'t exist in live index')
-        }
+      if (argv.printDocument) {
+        console.log('Built document:\n_______________________________________________________')
+        console.log(JSON.stringify(localEsRecord, null, 2))
       }
-    }).catch(e => {
-      console.error(`Compare-With-Indexed encountered an error: ${e.message}`)
-      console.error(e.stack)
-      die()
-    })
+
+      if (liveEsRecord) {
+        printDiff(liveEsRecord, localEsRecord, argv.verbose)
+      } else {
+        console.log('Can\'t display diff because record doesn\'t exist in live index')
+      }
+    }
+  } catch (e) {
+    console.error(`Compare-With-Indexed encountered an error: ${e.message}`)
+    console.error(e.stack)
+    die()
+  }
 }
 
 run()

--- a/test/fixtures/bib-18101449.json
+++ b/test/fixtures/bib-18101449.json
@@ -1,0 +1,326 @@
+ {
+  "id": "18101449",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2021-11-30T13:18:58-05:00",
+  "createdDate": "2009-07-31T13:04:21-04:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "bca",
+      "name": "Bronx Library Center Adult"
+    },
+    {
+      "code": "mma",
+      "name": "Mid-Manhattan Adult"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "   ",
+    "name": "---"
+  },
+  "title": "Por Ti [sound recording]",
+  "author": "La Apuesta.",
+  "materialType": {
+    "code": "j  ",
+    "value": "MUSIC NON-CD"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": null,
+  "catalogDate": null,
+  "country": {
+    "code": "   ",
+    "name": "No country"
+  },
+  "normTitle": "por ti sound recording",
+  "normAuthor": "la apuesta",
+  "standardNumbers": [],
+  "controlNumber": "",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "   ",
+      "display": "---"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "0",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "multi",
+      "display": null
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "0",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "j  ",
+      "display": "MUSIC NON-CD"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "18101449",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2009-07-31T13:04:21Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2021-11-30T13:18:58Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "4",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "   ",
+      "display": "No country"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2011-07-05T22:12:38Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "a",
+      "marcTag": "100",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "La Apuesta."
+        }
+      ]
+    },
+    {
+      "fieldTag": "i",
+      "marcTag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": ""
+        },
+        {
+          "tag": "c",
+          "content": "$13.99"
+        }
+      ]
+    },
+    {
+      "fieldTag": "i",
+      "marcTag": "024",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "827865369123"
+        }
+      ]
+    },
+    {
+      "fieldTag": "i",
+      "marcTag": "028",
+      "ind1": "4",
+      "ind2": "2",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "UMM369123C"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Compact disc."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "05/26/2009"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "505",
+      "ind1": "0",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "t",
+          "content": "Por ti"
+        },
+        {
+          "tag": "t",
+          "content": "El muchacho alegre"
+        },
+        {
+          "tag": "t",
+          "content": "Si supieras"
+        },
+        {
+          "tag": "t",
+          "content": "Procuro olvidarte"
+        },
+        {
+          "tag": "t",
+          "content": "El venadito"
+        },
+        {
+          "tag": "t",
+          "content": "Abrazame y perdoname"
+        },
+        {
+          "tag": "t",
+          "content": "Nieves de enero"
+        },
+        {
+          "tag": "t",
+          "content": "Cada dia mas"
+        },
+        {
+          "tag": "t",
+          "content": "Alma"
+        },
+        {
+          "tag": "t",
+          "content": "El taconazo"
+        },
+        {
+          "tag": "t",
+          "content": "Juan colorado"
+        },
+        {
+          "tag": "t",
+          "content": "Dos seres que se aman."
+        }
+      ]
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "b",
+          "content": "Universal Music Latino,"
+        },
+        {
+          "tag": "c",
+          "content": "2009."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Por Ti"
+        },
+        {
+          "tag": "h",
+          "content": "[sound recording] /"
+        },
+        {
+          "tag": "c",
+          "content": "La Apuesta."
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "910",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "BL"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000njm  22001572a 4500",
+      "subfields": null
+    }
+  ]
+}

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -90,7 +90,7 @@ describe('index handler function', () => {
     })
     it('calls lambda callback on successful indexing', async () => {
       eventDecoderStub('Item')
-      stub(platformApi, 'bibsForHoldingsOrItems').resolves([{ id: '1' }])
+      stub(platformApi, 'bibsForHoldingsOrItems').resolves([{ id: '1', locations: [{ code: 'mal92' }] }])
 
       // Note we can send in an invalid event because of above eventDecoder
       // stub, which always returns a fake item:

--- a/test/unit/prefilter.test.js
+++ b/test/unit/prefilter.test.js
@@ -1,0 +1,39 @@
+const { expect } = require('chai')
+
+const { filteredSierraBibsForBibs } = require('../../lib/prefilter')
+
+describe.only('prefilter', () => {
+  describe('filteredSierraBibsForBibs', () => {
+    it('should keep Research bibs', () => {
+      const bibs = [require('../fixtures/bib-11606020.json')]
+      const { filteredBibs, bibsToDelete } = filteredSierraBibsForBibs(bibs)
+
+      expect(filteredBibs).to.have.lengthOf(1)
+      expect(bibsToDelete).to.have.lengthOf(0)
+    })
+
+    it('should filter out non-Research bibs', () => {
+      const bibs = [require('../fixtures/bib-18101449.json')]
+      const { filteredBibs, bibsToDelete } = filteredSierraBibsForBibs(bibs)
+
+      expect(filteredBibs).to.have.lengthOf(0)
+      expect(bibsToDelete).to.have.lengthOf(1)
+    })
+
+    it('should filter out deleted bibs', () => {
+      const bibs = [require('../fixtures/bib-19099433.json')]
+      const { filteredBibs, bibsToDelete } = filteredSierraBibsForBibs(bibs)
+
+      expect(filteredBibs).to.have.lengthOf(0)
+      expect(bibsToDelete).to.have.lengthOf(1)
+    })
+
+    it('should filter out suppressed bibs', () => {
+      const bibs = [{ suppressed: true }]
+      const { filteredBibs, bibsToDelete } = filteredSierraBibsForBibs(bibs)
+
+      expect(filteredBibs).to.have.lengthOf(0)
+      expect(bibsToDelete).to.have.lengthOf(1)
+    })
+  })
+})

--- a/test/unit/prefilter.test.js
+++ b/test/unit/prefilter.test.js
@@ -1,39 +1,119 @@
 const { expect } = require('chai')
 
-const { filteredSierraBibsForBibs } = require('../../lib/prefilter')
+const {
+  filteredSierraBibsForBibs,
+  filteredSierraItemsForItems
+} = require('../../lib/prefilter')
 
-describe.only('prefilter', () => {
+describe('prefilter', () => {
   describe('filteredSierraBibsForBibs', () => {
     it('should keep Research bibs', () => {
       const bibs = [require('../fixtures/bib-11606020.json')]
-      const { filteredBibs, bibsToDelete } = filteredSierraBibsForBibs(bibs)
+      const { filteredBibs, removedBibs } = filteredSierraBibsForBibs(bibs)
 
       expect(filteredBibs).to.have.lengthOf(1)
-      expect(bibsToDelete).to.have.lengthOf(0)
+      expect(removedBibs).to.have.lengthOf(0)
     })
 
     it('should filter out non-Research bibs', () => {
       const bibs = [require('../fixtures/bib-18101449.json')]
-      const { filteredBibs, bibsToDelete } = filteredSierraBibsForBibs(bibs)
+      const { filteredBibs, removedBibs } = filteredSierraBibsForBibs(bibs)
 
       expect(filteredBibs).to.have.lengthOf(0)
-      expect(bibsToDelete).to.have.lengthOf(1)
+      expect(removedBibs).to.have.lengthOf(1)
     })
 
     it('should filter out deleted bibs', () => {
       const bibs = [require('../fixtures/bib-19099433.json')]
-      const { filteredBibs, bibsToDelete } = filteredSierraBibsForBibs(bibs)
+      const { filteredBibs, removedBibs } = filteredSierraBibsForBibs(bibs)
 
       expect(filteredBibs).to.have.lengthOf(0)
-      expect(bibsToDelete).to.have.lengthOf(1)
+      expect(removedBibs).to.have.lengthOf(1)
     })
 
     it('should filter out suppressed bibs', () => {
       const bibs = [{ suppressed: true }]
-      const { filteredBibs, bibsToDelete } = filteredSierraBibsForBibs(bibs)
+      const { filteredBibs, removedBibs } = filteredSierraBibsForBibs(bibs)
 
       expect(filteredBibs).to.have.lengthOf(0)
-      expect(bibsToDelete).to.have.lengthOf(1)
+      expect(removedBibs).to.have.lengthOf(1)
+    })
+  })
+
+  describe('filteredSierraItemsForItems', () => {
+    it('should filter out items with branch locations', () => {
+      const items = [{ location: { code: 'aga01' } }]
+      const filteredItems = filteredSierraItemsForItems(items)
+
+      expect(filteredItems).to.have.lengthOf(0)
+    })
+
+    it('should keep items with Research locations', () => {
+      const items = [{ location: { code: 'mal92' } }]
+      const filteredItems = filteredSierraItemsForItems(items)
+
+      expect(filteredItems).to.have.lengthOf(1)
+    })
+
+    it('should filter out items with non-Research item types', () => {
+      const items = [{ fixedFields: [{ label: 'Item Type', value: 120 }] }]
+      const filteredItems = filteredSierraItemsForItems(items)
+
+      expect(filteredItems).to.have.lengthOf(0)
+    })
+
+    it('should keep items with Research item types', () => {
+      const items = [{ fixedFields: [{ label: 'Item Type', value: 6 }] }]
+      const filteredItems = filteredSierraItemsForItems(items)
+
+      expect(filteredItems).to.have.lengthOf(1)
+    })
+
+    it('should filter out partner items marked Private in 876 $x or 900 $a', () => {
+      const items = [
+        {
+          nyplSource: 'recap-pul',
+          varFields: [
+            { marcTag: '876', subFields: [{ tag: 'x', content: 'Private' }] }
+          ]
+        },
+        {
+          nyplSource: 'recap-hl',
+          varFields: [
+            { marcTag: '900', subFields: [{ tag: 'a', content: 'Private' }] }
+          ]
+        }
+      ]
+      const filteredItems = filteredSierraItemsForItems(items)
+
+      expect(filteredItems).to.have.lengthOf(0)
+    })
+
+    it('should filter out items suppessed by Item Type 50', () => {
+      const items = [{ fixedFields: [{ label: 'Item Type', value: 50 }] }]
+      const filteredItems = filteredSierraItemsForItems(items)
+
+      expect(filteredItems).to.have.lengthOf(0)
+    })
+
+    it('should filter out items suppessed by Item Code 2', () => {
+      // Generate a fake Research items for each of the known suppressable
+      // Icode2 values. Add non-suppressed icode2 'a' as a control:
+      const items = ['s', 'w', 'd', 'p', 'a']
+        .map((icode2) => {
+          return {
+            // Give the fake item a Research location so that it would
+            // otherwise appear to be Research:
+            location: { code: 'mal92' },
+            // Give it the Icode2 value:
+            fixedFields: [{ label: 'Item Code 2', value: icode2 }]
+          }
+        })
+      const filteredItems = filteredSierraItemsForItems(items)
+
+      expect(filteredItems).to.have.lengthOf(1)
+      // Expect only the item with an innocuous Item Code 2 value to survive:
+      expect(filteredItems[0].fixedFields[0].value).to.equal('a')
     })
   })
 })

--- a/test/unit/sierra-bib.test.js
+++ b/test/unit/sierra-bib.test.js
@@ -16,7 +16,7 @@ describe('SierraBib', function () {
       const bib = new SierraBib(require('../fixtures/bib-10001936-suppressed.json'))
       expect(bib.getSuppressionWithRationale()).to.deep.equal({
         suppressed: true,
-        rationale: 'suppressed'
+        rationale: 'Suppressed'
       })
     })
 
@@ -24,7 +24,7 @@ describe('SierraBib', function () {
       const bib = new SierraBib(require('../fixtures/bib-10001936-deleted.json'))
       expect(bib.getSuppressionWithRationale()).to.deep.equal({
         suppressed: true,
-        rationale: 'deleted'
+        rationale: 'Deleted'
       })
     })
 
@@ -33,7 +33,7 @@ describe('SierraBib', function () {
         const bib = new SierraBib(require('../fixtures/bib-10001936-os.json'))
         expect(bib.getSuppressionWithRationale()).to.deep.equal({
           suppressed: true,
-          rationale: 'is-otf'
+          rationale: 'Is OTF'
         })
       })
 
@@ -41,7 +41,7 @@ describe('SierraBib', function () {
         const bib = new SierraBib(require('../fixtures/bib-10001936-910a.json'))
         expect(bib.getSuppressionWithRationale()).to.deep.equal({
           suppressed: true,
-          rationale: 'is-otf'
+          rationale: 'Is OTF'
         })
       })
     })

--- a/test/unit/sierra-item.test.js
+++ b/test/unit/sierra-item.test.js
@@ -25,7 +25,7 @@ describe('SierraItem', function () {
 
         expect(item.getSuppressionWithRationale()).to.deep.equal({
           suppressed: true,
-          rationale: ['876 $x']
+          rationale: ['Partner 876 $x']
         })
       })
     })
@@ -47,7 +47,7 @@ describe('SierraItem', function () {
 
         expect(item.getSuppressionWithRationale()).to.deep.equal({
           suppressed: true,
-          rationale: ['900 $a']
+          rationale: ['Partner 900 $a']
         })
       })
     })
@@ -60,7 +60,7 @@ describe('SierraItem', function () {
 
         expect(item.getSuppressionWithRationale()).to.deep.equal({
           suppressed: true,
-          rationale: ['deleted']
+          rationale: ['Deleted']
         })
       })
     })
@@ -78,7 +78,7 @@ describe('SierraItem', function () {
 
         expect(item.getSuppressionWithRationale()).to.deep.equal({
           suppressed: true,
-          rationale: ['catalogItemType']
+          rationale: ['Item Type 50']
         })
       })
     })
@@ -100,7 +100,7 @@ describe('SierraItem', function () {
         items.forEach((item) => {
           return expect(item.getSuppressionWithRationale()).to.deep.equal({
             suppressed: true,
-            rationale: ['fixed "Item Code 2"']
+            rationale: ['Restricted icode2']
           })
         })
       })
@@ -131,9 +131,10 @@ describe('SierraItem', function () {
         })
       const item = new SierraItem(itemData)
 
+      console.log(item.getSuppressionWithRationale())
       expect(item.getSuppressionWithRationale()).to.deep.equal({
         suppressed: true,
-        rationale: ['deleted', 'catalogItemType']
+        rationale: ['Deleted', 'Item Type 50']
       })
     })
   })

--- a/test/unit/utils-locations.test.js
+++ b/test/unit/utils-locations.test.js
@@ -14,7 +14,7 @@ describe('utils/locations', () => {
 
     it('returns false for location with non-matching collectionType', () => {
       expect(locationHasExclusiveCollectionType('mal92', 'Branch')).to.equal(false)
-      expect(locationHasExclusiveCollectionType('aga01', 'Resaerch')).to.equal(false)
+      expect(locationHasExclusiveCollectionType('aga01', 'Research')).to.equal(false)
     })
 
     it('returns false for location with non-exclusive matching collectionType', () => {

--- a/test/unit/utils-locations.test.js
+++ b/test/unit/utils-locations.test.js
@@ -1,0 +1,34 @@
+const expect = require('chai').expect
+
+const {
+  locationHasExclusiveCollectionType,
+  locationHasResearchCenterPrefix
+} = require('../../lib/utils/locations')
+
+describe('utils/locations', () => {
+  describe('locationHasExclusiveCollectionType', () => {
+    it('returns true for location with matching collectionType', () => {
+      expect(locationHasExclusiveCollectionType('mal92', 'Research')).to.equal(true)
+      expect(locationHasExclusiveCollectionType('aga01', 'Branch')).to.equal(true)
+    })
+
+    it('returns false for location with non-matching collectionType', () => {
+      expect(locationHasExclusiveCollectionType('mal92', 'Branch')).to.equal(false)
+      expect(locationHasExclusiveCollectionType('aga01', 'Resaerch')).to.equal(false)
+    })
+
+    it('returns false for location with non-exclusive matching collectionType', () => {
+      // Location ia has both Research and Branch:
+      expect(locationHasExclusiveCollectionType('ia', 'Research')).to.equal(false)
+      expect(locationHasExclusiveCollectionType('ia', 'Branch')).to.equal(false)
+    })
+  })
+
+  describe('locationHasResearchCenterPrefix', () => {
+    it('returns true for Research prefixed location ids', () => {
+      expect(locationHasResearchCenterPrefix('mal')).to.equal(true)
+      expect(locationHasResearchCenterPrefix('sc1234')).to.equal(true)
+      expect(locationHasResearchCenterPrefix('pathispartcanbeanything')).to.equal(true)
+    })
+  })
+})


### PR DESCRIPTION
 Incorporate suppression and is-research checks

 - Add isResearch and supporting methods to Sierra models to ensure we
   don't index Circ records
 - Reorganize build-es-document to ensure we apply is-research and
   suppression checks on bibs regardless of the original event type
 - Update compare-with-indexed script to add support for holding ids and
   inumbers