### PR TITLE
Add ItemVolume to aeon URL

### DIFF
--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -233,15 +233,17 @@ class EsItem extends EsBase {
   }
 
   // ToDO: getting callnum from bib
-  shelfMark () {
+  shelfMark (addVolume = true) {
     let callnum = this._callNum()
     // If not found in var field
     if (callnum) {
-      // Pull callnumber suffix from fieldTag v if present
-      const callnumSuffix = this.item.fieldTag('v')[0]?.value
+      if (addVolume) {
+        // Pull callnumber suffix from fieldTag v if present
+        const callnumSuffix = this.item.fieldTag('v')[0]?.value
 
-      if (callnumSuffix) {
-        callnum += ' ' + callnumSuffix
+        if (callnumSuffix) {
+          callnum += ' ' + callnumSuffix
+        }
       }
 
       // Finally store the complete shelfMark data

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -144,6 +144,40 @@ const firstValue = (array) => {
   return array[0]
 }
 
+/**
+ *  Given an array of objects and an async function that generates a sort key
+ *  for any member of the input array, returns the original array sorted by the
+ *  generated sort keys.
+ *
+ *  @param {object[]} array - Array of objects to sort
+ *  @param {function} sortKeyGetter - An async function that returns a sortable scalar value
+ *  @param {string} direction - Either 'asc' or 'desc'. Default 'asc'
+ */
+const sortByAsyncSortKey = async (array, sortKeyGetter, direction = 'asc') => {
+  const sortableKeyElementPairs = await Promise.all(
+    array.map(async (element) => {
+      return [await sortKeyGetter(element), element]
+    })
+  )
+  sortableKeyElementPairs.sort((pair1, pair2) => {
+    const comparison = pair1[0] < pair2[0] ? -1 : 1
+    return comparison * (direction === 'asc' ? 1 : -1)
+  })
+  return sortableKeyElementPairs.map((pair) => pair[1])
+}
+
+/**
+ *  Simple util for truncating a string to the specified length and adding a
+ *  ellipse suffix indicating that a truncation has occurred.
+ */
+const truncate = (s, length) => {
+  if (!s || s.length <= length) return s
+
+  // Use unicode ellipsis ( https://www.compart.com/en/unicode/U+2026 ):
+  const suffix = '…'
+  return s.substring(0, length - suffix.length) + suffix
+}
+
 module.exports = {
   isValidResponse,
   addSierraCheckDigit,
@@ -154,5 +188,7 @@ module.exports = {
   unique,
   dupeObjectsByHash,
   uniqueObjectsByHash,
-  firstValue
+  firstValue,
+  sortByAsyncSortKey,
+  truncate
 }

--- a/lib/utils/aeon-urls.js
+++ b/lib/utils/aeon-urls.js
@@ -1,20 +1,9 @@
 const { firstValue, addSierraCheckDigit, trimTrailingPunctuation } = require('../utils')
 const logger = require('../logger')
+const { truncate } = require('../utils')
 const { lookup } = require('./lookup')
 
 const locationLabelMap = lookup('aeon-site-code-to-label')
-
-/**
- *  Simple util for truncating a string to the specified length and adding a
- *  ellipse suffix indicating that a truncation has occurred.
- */
-const truncate = (s, length) => {
-  if (!s || s.length <= length) return s
-
-  // Use unicode ellipsis ( https://www.compart.com/en/unicode/U+2026 ):
-  const suffix = '…'
-  return s.substring(0, length - suffix.length) + suffix
-}
 
 /**
  *  Given a EsItem, returns an Aeon URL
@@ -37,7 +26,8 @@ const aeonUrlForItem = async (esItem) => {
 
   const baseUrl = aeonBaseUrl + '/aeon/Aeon.dll?'
 
-  const sierraBib = esItem.item.bibs() && esItem.item.bibs().length ? esItem.item.bibs()[0] : null
+  const sierraItem = esItem.item
+  const sierraBib = sierraItem.bibs() && sierraItem.bibs().length ? sierraItem.bibs()[0] : null
 
   const accessMessageLabel = (firstValue(esItem.accessMessage()) || {}).label
   const materialTypeLabel = sierraBib?.materialType?.value
@@ -56,11 +46,12 @@ const aeonUrlForItem = async (esItem) => {
   const locationLabel = locationLabelMap[siteCode]
   const holdingLocationId = firstValue(esItem.holdingLocation())?.id?.split(':').pop()
   const isReCAP = /^rc/.test(holdingLocationId)
+  const itemVolume = sierraItem.fieldTag('v')[0]?.value
 
   const props = {
     Action: 10,
     Author: firstValue(esItem.esBib?.creatorLiteral()) || '',
-    CallNumber: firstValue(esItem.shelfMark()) || '',
+    CallNumber: firstValue(esItem.shelfMark(false)) || '',
     Date: firstValue(esItem.esBib?.createdString()) || '',
     Form: 30,
     Genre: materialTypeLabel || '',
@@ -72,6 +63,7 @@ const aeonUrlForItem = async (esItem) => {
     ItemNumber: firstValue(esItem.idBarcode()) || '',
     ItemPlace: firstValue(esItem.esBib?.placeOfPublication()) || '',
     ItemPublisher: firstValue(esItem.esBib?.publisherLiteral()) || '',
+    ItemVolume: itemVolume,
     Location: isReCAP ? 'ReCAP' : (locationLabel || ''),
     ReferenceNumber: addSierraCheckDigit(bibUri),
     Site: siteCode,

--- a/lib/utils/aeon-urls.js
+++ b/lib/utils/aeon-urls.js
@@ -27,7 +27,7 @@ const aeonUrlForItem = async (esItem) => {
   const baseUrl = aeonBaseUrl + '/aeon/Aeon.dll?'
 
   const sierraItem = esItem.item
-  const sierraBib = sierraItem.bibs() && sierraItem.bibs().length ? sierraItem.bibs()[0] : null
+  const sierraBib = sierraItem.bibs()?.length ? sierraItem.bibs()[0] : null
 
   const accessMessageLabel = (firstValue(esItem.accessMessage()) || {}).label
   const materialTypeLabel = sierraBib?.materialType?.value

--- a/test/unit/utils-aeon-urls.test.js
+++ b/test/unit/utils-aeon-urls.test.js
@@ -43,7 +43,7 @@ describe('aeonn-urls', () => {
 
     const url = await aeonUrlForItem(esItem)
     // Note no esBib is associated, so fields are unnaturally light:
-    expect(url).to.eq('https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=Sc+Visual+DVD-362+Disc+2&Form=30&ItemInfo1=Use+in+library&ItemISxN=i375287097&ItemNumber=33433124443791&Location=Schomburg+Moving+Image+and+Recorded+Sound&Site=SCHMIRS')
+    expect(url).to.eq('https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=Sc+Visual+DVD-362&Form=30&ItemInfo1=Use+in+library&ItemISxN=i375287097&ItemNumber=33433124443791&ItemVolume=Disc+2&Location=Schomburg+Moving+Image+and+Recorded+Sound&Site=SCHMIRS')
   })
 
   it('returns Aeon URL with metadata fields pulled from bib', async () => {
@@ -58,7 +58,7 @@ describe('aeonn-urls', () => {
     expect(baseUrl).to.equal('https://specialcollections.nypl.org/aeon/Aeon.dll')
     expect(parseQueryString(queryString)).to.deep.equal({
       Action: '10',
-      CallNumber: 'Sc Visual DVD-362 Disc 2',
+      CallNumber: 'Sc Visual DVD-362',
       Date: '2012',
       Form: '30',
       Genre: 'DVD',
@@ -69,6 +69,7 @@ describe('aeonn-urls', () => {
       ItemNumber: '33433124443791',
       ItemPlace: 'New York',
       ItemPublisher: 'Schomburg Center for Research in Black Culture',
+      ItemVolume: 'Disc 2',
       ReferenceNumber: 'b220279536',
       Site: 'SCHMIRS',
       Title: 'Documenting history in your own backyard : a symposium for archiving & preserving hip-hop culture'
@@ -78,6 +79,8 @@ describe('aeonn-urls', () => {
   it('encodes diacritics', async () => {
     const sierraItem = new SierraItem(require('../fixtures/item-37528709.json'))
     const sierraBib = new SierraBib({
+      nyplSource: 'sierra-nypl',
+      id: '1234',
       varFields: [
         {
           marcTag: '245',
@@ -95,7 +98,7 @@ describe('aeonn-urls', () => {
     const esItem = new EsItem(sierraItem, new EsBib(sierraBib))
 
     const url = await aeonUrlForItem(esItem)
-    expect(url).to.eq('https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=Sc+Visual+DVD-362+Disc+2&Form=30&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Dundefined&ItemISxN=i375287097&ItemNumber=33433124443791&Location=Schomburg+Moving+Image+and+Recorded+Sound&Site=SCHMIRS&Title=Token1+T%C3%B6ken2+Tok%C3%A9n3+Toke%C3%B14+Token5')
+    expect(url).to.eq('https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=Sc+Visual+DVD-362&Form=30&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db1234&ItemISxN=i375287097&ItemNumber=33433124443791&ItemVolume=Disc+2&Location=Schomburg+Moving+Image+and+Recorded+Sound&ReferenceNumber=b12348&Site=SCHMIRS&Title=Token1+T%C3%B6ken2+Tok%C3%A9n3+Toke%C3%B14+Token5')
 
     const [, queryString] = url.split('?')
     expect(parseQueryString(queryString).Title).to.equal(

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -86,4 +86,49 @@ describe('utils', () => {
       expect(utils.addSierraCheckDigit('i15897007')).to.equal('i15897007x')
     })
   })
+
+  describe('sortByAsyncSortKey', () => {
+    it('sorts array of values by an async getter', async () => {
+      const input = ['element 2', 'element 1', 'element 4', 'element 3']
+      const sorted = await utils.sortByAsyncSortKey(input, (element) => Promise.resolve(element))
+      expect(sorted).to.deep.equal([
+        'element 1', 'element 2', 'element 3', 'element 4'
+      ])
+    })
+
+    it('sorts array of values by an async member function', async () => {
+      const input = [
+        { id: 'element 2', sortKey: () => Promise.resolve(2) },
+        { id: 'element 1', sortKey: () => Promise.resolve(1) },
+        { id: 'element 4', sortKey: () => Promise.resolve(4) },
+        { id: 'element 3', sortKey: () => Promise.resolve(3) }
+      ]
+      const sorted = await utils.sortByAsyncSortKey(input, (element) => element.sortKey())
+      expect(sorted.map((el) => el.id)).to.deep.equal([
+        'element 1', 'element 2', 'element 3', 'element 4'
+      ])
+    })
+
+    it('supports reverse sorting', async () => {
+      const input = ['element 2', 'element 1', 'element 4', 'element 3']
+      const sorted = await utils.sortByAsyncSortKey(input, (element) => Promise.resolve(element), 'desc')
+      expect(sorted).to.deep.equal([
+        'element 4', 'element 3', 'element 2', 'element 1'
+      ])
+    })
+  })
+
+  describe('truncate', () => {
+    it('returns original value if unable to truncate', () => {
+      expect(utils.truncate('')).to.equal('')
+      expect(utils.truncate(false)).to.equal(false)
+      expect(utils.truncate(undefined)).to.equal(undefined)
+    })
+
+    it('truncates strings to length', () => {
+      expect(utils.truncate('123456789', 4)).to.equal('123…')
+      expect(utils.truncate('123456789', 4)).to.have.lengthOf(4)
+      expect(utils.truncate('123456789', 40)).to.equal('123456789')
+    })
+  })
 })


### PR DESCRIPTION
By request, adding a new ItemVolume= param to Aeon URLS to hold volume information. (Removing it from CallNumber)