### PR TITLE
Fix issue excluding volumeRanges beyond int bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: focal
-language: node_js
-install:
-- npm i
-jobs:
-  include:
-  - stage: test
-    script: npm test

--- a/lib/utils/volume-parse.js
+++ b/lib/utils/volume-parse.js
@@ -43,12 +43,16 @@ const extractVols = (matches) => {
     // extract the numbers from regex array-like object
     match = match.slice(1, 3)
       // Eliminate null values
-      .filter(m => m)
+      .filter((m) => m)
       // convert from string to int
-      .map(m => parseInt(m, 10))
+      .map((m) => parseInt(m, 10))
+      // Ensure values are within ES int ( https://www.elastic.co/guide/en/elasticsearch/reference/5.3/number.html )
+      .filter((num) => Math.abs(num) <= Math.pow(2, 31) - 1)
+
     // [6,7,8] ==> [6,8]
     if (match.length > 2) match = [match[0], match[match.length - 1]]
     if (match.length === 1) match = [match[0], match[0]]
+
     return [...vols, match]
   }, [])
 }

--- a/test/unit/utils-volume-parse.test.js
+++ b/test/unit/utils-volume-parse.test.js
@@ -1,0 +1,63 @@
+const expect = require('chai').expect
+
+const { parseVolume } = require('../../lib/utils/volume-parse')
+
+describe('utils/volume-parse', () => {
+  describe('parseVolume', () => {
+    it('v. 36-37 (Nov. 1965-Oct. 1967)', () => {
+      expect(parseVolume('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([[36, 37]])
+    })
+
+    it('vol. 67 (May-Oct. 1996)', () => {
+      expect(parseVolume('vol. 67 (May-Oct. 1996')).to.deep.equal([[67, 67]])
+    })
+
+    it('volume 10, no. 1 - 4 (win. - aut. 1976) inde', () => {
+      expect(parseVolume('volume 10, no. 1 - 4 (win. - aut. 1976) inde')).to.deep.equal([[10, 10]])
+    })
+
+    it('vol 93, no. 3 (autumn 2013)', () => {
+      expect(parseVolume('vol 93, no. 3 (autumn 2013)')).to.deep.equal([[93, 93]])
+    })
+
+    it('v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)', () => {
+      expect(parseVolume('v. 6-7 no. 2, 5-v. 8 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)')).to.deep.equal([[6, 7], [8, 8]])
+    })
+
+    it('v. 6-7 no. 2, 5-v. 8-10 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)', () => {
+      expect(parseVolume('v. 6-7 no. 2, 5-v. 8-10 no. 1 (Oct. 1961-Sept./Oct. 1962, May-June/July 1963)')).to.deep.equal([[6, 7], [8, 10]])
+    })
+
+    it('returns empty array for strings without obvious volume information', () => {
+      expect(parseVolume('')).to.deep.equal(null)
+      expect(parseVolume('vol')).to.deep.equal([])
+      expect(parseVolume('no. a')).to.deep.equal([])
+      expect(parseVolume('May-June/July 1963')).to.deep.equal([])
+      expect(parseVolume('Sc News Daily monitor (Kampala, Uganda) Dec. 1-25,27-31, 2018')).to.deep.equal([])
+    })
+
+    it('matches on a single number', () => {
+      expect(parseVolume('23')).to.deep.equal([[23, 23]])
+    })
+
+    it('jaarg. 24 (Jan.-June 1967)', () => {
+      expect(parseVolume('jaarg. 24 (Jan.-June 1967)')).to.deep.equal([[24, 24]])
+    })
+
+    it('rejects volumes beyond the range of ints', () => {
+      // This is a volume value just within the accepted int range:
+      const maxInt = Math.pow(2, 31) - 1
+
+      expect(parseVolume(`volume ${maxInt}`)).to.deep.equal([[maxInt, maxInt]])
+
+      // This is a volume value just outside accepted int range:
+      expect(parseVolume(`volume ${maxInt + 1}`)).to.deep.equal([])
+
+      // This is a volume value outside accepted int range:
+      expect(parseVolume('volume 7600010780000')).to.deep.equal([])
+
+      // Should reject only the invalid int:
+      expect(parseVolume('volume 1 - 7600010780000')).to.deep.equal([[1, 1]])
+    })
+  })
+})


### PR DESCRIPTION
Fixes production issue where a parsed volume exceeds integer range, leading to a ES write error. Adds full set of tests for volume parsing.

Also removes `.travis.yml` because we rely on gh actions for tests.