### PR TITLE
Fix bug identifying newer rc locations as Research

### DIFF
--- a/lib/utils/locations.js
+++ b/lib/utils/locations.js
@@ -18,10 +18,10 @@ const locationHasExclusiveCollectionType = (locationId, collectionType) => {
 /**
  *  Given a location id (e.g. 'mal92', 'abcd12'), returns true if location id
  *  has a known Research Center prefix (i.e. is likely SASB/Schomburg/LPA
- *  Research)
+ *  Research) OR the ReCAP prefix (rc)
  */
 const locationHasResearchCenterPrefix = (locationId) => {
-  return /^(ma|sc|pa)/.test(locationId)
+  return /^(ma|sc|pa|rc)/.test(locationId)
 }
 
 module.exports = {

--- a/test/unit/sierra-item.test.js
+++ b/test/unit/sierra-item.test.js
@@ -137,4 +137,57 @@ describe('SierraItem', function () {
       })
     })
   })
+
+  describe('getIsResearchWithRationale', () => {
+    it('returns true for partner items', () => {
+      const item = new SierraItem(require('../fixtures/item-pul-189241.json'))
+      expect(item.getIsResearchWithRationale()).to.deep.equal({
+        isResearch: true,
+        rationale: 'Is partner record'
+      })
+    })
+
+    it('returns true for items with locations tagged Research in NYPL-Core', () => {
+      const item = new SierraItem(require('../fixtures/item-10003973.json'))
+      expect(item.getIsResearchWithRationale()).to.deep.equal({
+        isResearch: true,
+        rationale: 'Has research location'
+      })
+    })
+
+    it('returns true for items with rc location that is not yet tagged Research in NYPL-Core', () => {
+      const itemData = JSON.parse(JSON.stringify(require('../fixtures/item-10003973.json')))
+      itemData.location.code = 'rc-new-location-id'
+      const item = new SierraItem(itemData)
+      expect(item.getIsResearchWithRationale()).to.deep.equal({
+        isResearch: true,
+        rationale: 'Has likely Research location: rc-new-location-id'
+      })
+    })
+
+    it('returns true for items with Ressearch item types', () => {
+      const item = new SierraItem({
+        id: '1234',
+        nyplSource: 'sierra-nypl',
+        fixedFields: [{ label: 'Item Type', value: '6' }]
+      })
+      expect(item.getIsResearchWithRationale()).to.deep.equal({
+        isResearch: true,
+        rationale: 'Item type 6 implies research'
+      })
+    })
+
+    it('returns false for items that fail all Research checks', () => {
+      const item = new SierraItem({
+        id: '1234',
+        nyplSource: 'sierra-nypl',
+        location: { code: 'zzzzz' },
+        fixedFields: [{ label: 'Item Type', value: '123' }]
+      })
+      expect(item.getIsResearchWithRationale()).to.deep.equal({
+        isResearch: false,
+        rationale: 'Location (zzzzz) and Item Type (123) collectionTypes are not Research'
+      })
+    })
+  })
 })

--- a/test/unit/utils-locations.test.js
+++ b/test/unit/utils-locations.test.js
@@ -29,6 +29,13 @@ describe('utils/locations', () => {
       expect(locationHasResearchCenterPrefix('mal')).to.equal(true)
       expect(locationHasResearchCenterPrefix('sc1234')).to.equal(true)
       expect(locationHasResearchCenterPrefix('pathispartcanbeanything')).to.equal(true)
+      expect(locationHasResearchCenterPrefix('rcwhatever')).to.equal(true)
+    })
+
+    it('returns false for not-Research prefixed location ids', () => {
+      expect(locationHasResearchCenterPrefix('zzz')).to.equal(false)
+      expect(locationHasResearchCenterPrefix('')).to.equal(false)
+      expect(locationHasResearchCenterPrefix('aga01')).to.equal(false)
     })
   })
 })


### PR DESCRIPTION
Updates the location prefix check to ensure that we assume items in any "rc" prefixed location are ReCAP even if we don't yet have them in NYPL-Core.

Also adds several tests to improve coverage of the `getIsResearchWithRationale` call.