### PR TITLE
Fix aeon bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const eventDecoder = require('./lib/event-decoder')
 const elastic = require('./lib/elastic-search/requests')
 const { suppressBibs } = require('./lib/utils/suppressBibs')
 const { buildEsDocument } = require('./lib/build-es-document')
+const { truncate } = require('./lib/utils')
 
 /**
  * Main lambda handler receiving Bib, Item, and Holding events
@@ -19,8 +20,9 @@ const handler = async (event, context, callback) => {
     let message = ''
     if (recordsToIndex.length) {
       await elastic.writeRecords(recordsToIndex)
+      const summary = truncate(recordsToIndex.map((record) => record.uri).join(','), 100)
 
-      message = `Wrote ${recordsToIndex.length} doc(s)`
+      message = `Wrote ${recordsToIndex.length} doc(s): ${summary}`
     }
 
     if (recordsToDelete.length) {

--- a/index.js
+++ b/index.js
@@ -20,8 +20,9 @@ const handler = async (event, context, callback) => {
     let message = ''
     if (recordsToIndex.length) {
       await elastic.writeRecords(recordsToIndex)
-      const summary = truncate(recordsToIndex.map((record) => record.uri).join(','), 100)
 
+      // Log out a summary of records updated:
+      const summary = truncate(recordsToIndex.map((record) => record.uri).join(','), 100)
       message = `Wrote ${recordsToIndex.length} doc(s): ${summary}`
     }
 

--- a/lib/utils/aeon-urls.js
+++ b/lib/utils/aeon-urls.js
@@ -37,7 +37,7 @@ const aeonUrlForItem = async (esItem) => {
     .pop()
   // In addition to the typical title subfields a and b, also query k, f, and g:
   const extendedTitle = sierraBib?.varField('245', ['a', 'b', 'k', 'f', 'g'])
-    .map((match) => match.value)
+    .map((match) => match.parallel?.value || match.value)
     .map((s) => trimTrailingPunctuation(s))
     .pop()
   const useStatement = sierraBib?.varField('506', ['a'])

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -98,7 +98,7 @@ describe('index handler function', () => {
       // stub, which always returns a fake item:
       await index.handler('some fake event data', null, callback)
       expect(callback.calledOnce).to.equal(true)
-      expect(callback).to.have.been.calledWith(null, 'Wrote 1 doc(s)')
+      expect(callback).to.have.been.calledWith(null, 'Wrote 1 doc(s): 1')
     })
   })
 

--- a/test/unit/utils-aeon-urls.test.js
+++ b/test/unit/utils-aeon-urls.test.js
@@ -146,4 +146,27 @@ describe('aeonn-urls', () => {
     )
     expect(useStatement.length).to.equal(255)
   })
+
+  it('uses parallel title when it exists', async () => {
+    const sierraItem = new SierraItem(require('../fixtures/item-37528709.json'))
+    const sierraBib = new SierraBib({
+      nyplSource: 'sierra-nypl',
+      id: '1234',
+      varFields: [
+        {
+          marcTag: '880',
+          subfields: [
+            { tag: '6', content: '245-01/(3/r' },
+            { tag: 'a', content: 'parallel value 1' },
+            { tag: 'b', content: 'parallel value 2' }
+          ]
+        }
+      ]
+    })
+    sierraItem._bibs = [sierraBib]
+    const esItem = new EsItem(sierraItem, new EsBib(sierraBib))
+
+    const url = await aeonUrlForItem(esItem)
+    expect(url).to.eq('https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&CallNumber=Sc+Visual+DVD-362&Form=30&ItemInfo1=Use+in+library&ItemInfo3=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db1234&ItemISxN=i375287097&ItemNumber=33433124443791&ItemVolume=Disc+2&Location=Schomburg+Moving+Image+and+Recorded+Sound&ReferenceNumber=b12348&Site=SCHMIRS&Title=parallel+value+1+parallel+value+2')
+  })
 })


### PR DESCRIPTION
Fixes a bug that came up testing Aeon links in QA. When building the `Title` param for Aeon links, we weren't expecting orphaned parallels. This fixes that (and opts to use the parallel value over the primary when it exists).