### PR TITLE
Add check for holdings with null location

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -276,7 +276,15 @@ class EsBib extends EsBase {
         this.bib.holdings()
           .map((h) => EsCheckinCardItem.fromSierraHolding(h, this))
           .reduce((acc, el) => acc.concat(el), [])
-          .filter(item => item.holdingLocation()[0].label !== 'Offsite')
+          .filter((item) => {
+            const holdingLocation = item.holdingLocation()
+            const isOffsite = holdingLocation &&
+              holdingLocation[0] &&
+              holdingLocation[0].label &&
+              holdingLocation[0].label === 'Offsite'
+
+            return !isOffsite
+          })
       )
     _items = await sortByAsyncSortKey(_items, (item) => item.shelfMark_sort(), 'desc')
     return _items

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1161,8 +1161,14 @@ describe('EsBib', function () {
       // Add holdings with Offsite location to check that they are filtered out
       const holding = require('../fixtures/holding-1032862.json')
       holding.location.code = 'rcmg8'
+
+      // Add a holding with no location to make sure it doesn't cause an error
+      const holding2 = JSON.parse(JSON.stringify(holding))
+      holding2.location = null
+
       sierraBib._holdings = [
-        new SierraHolding(holding)
+        new SierraHolding(holding),
+        new SierraHolding(holding2)
       ]
       bib = new EsBib(sierraBib)
     })
@@ -1170,7 +1176,7 @@ describe('EsBib', function () {
     it('filters out checkInCards with offsite locations', async () => {
       const items = await bib.items()
       expect(items).to.be.a('array')
-      expect(items).to.have.lengthOf(2)
+      expect(items).to.have.lengthOf(4)
     })
   })
 })


### PR DESCRIPTION
- Changes the way we check whether CheckinCards have an Offsite location to allow for `null` locations
- Changes tests to match the new code