### PR TITLE
Noref fix mediatype bug

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -855,15 +855,14 @@ class EsBib extends EsBase {
 
     if (useStrategies.includes('337')) {
       const matches = this.bib.varField('337', ['b', 'a'])
+        // Make sure the 337 has content (not just parallel content):
+        .filter((match) => match.subfieldMap)
       if (matches && matches.length) {
-        return matches
-          // Make sure the 337 has content (not just parallel content):
-          .filter((match) => match.subfieldMap)
-          .map((match) => {
-            const id = match.subfieldMap.b
-            const label = match.subfieldMap.a
-            return { id: `mediatypes:${id}`, label }
-          })
+        return matches.map((match) => {
+          const id = match.subfieldMap.b
+          const label = match.subfieldMap.a
+          return { id: `mediatypes:${id}`, label }
+        })
       }
     }
   }

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -856,11 +856,14 @@ class EsBib extends EsBase {
     if (useStrategies.includes('337')) {
       const matches = this.bib.varField('337', ['b', 'a'])
       if (matches && matches.length) {
-        return matches.map((match) => {
-          const id = match.subfieldMap.b
-          const label = match.subfieldMap.a
-          return { id: `mediatypes:${id}`, label }
-        })
+        return matches
+          // Make sure the 337 has content (not just parallel content):
+          .filter((match) => match.subfieldMap)
+          .map((match) => {
+            const id = match.subfieldMap.b
+            const label = match.subfieldMap.a
+            return { id: `mediatypes:${id}`, label }
+          })
       }
     }
   }

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -748,6 +748,26 @@ describe('EsBib', function () {
         label: 'some label'
       }])
     })
+
+    it('ignores 337 with no content (i.e. just parallel content)', () => {
+      const record = new SierraBib({
+        nyplSource: 'recap-pul',
+        varFields: [
+          {
+            marcTag: '880',
+            subfields: [
+              { tag: '6', content: '337-01/(3/r' },
+              { tag: 'a', content: 'some parallel content' },
+              { tag: 'b', content: 'some other parallel content' }
+            ]
+          }
+        ]
+      })
+      expect((new EsBib(record)).mediaType()).to.deep.equal([{
+        id: 'mediatypes:n',
+        label: 'unmediated'
+      }])
+    })
   })
 
   describe('mediaType_packed', () => {


### PR DESCRIPTION
Fix production bug encountered in partner record. Indexer assumed a 337 would have primary content, whereas some only have parallel content and should be ignored.