### PR TITLE
Change Aeon URL: Add $c to ItemPublisher

### DIFF
--- a/lib/utils/aeon-urls.js
+++ b/lib/utils/aeon-urls.js
@@ -51,6 +51,13 @@ const aeonUrlForItem = async (esItem) => {
   const isMaps = /^map/.test(holdingLocationId)
   const isReCAP = /^rc/.test(holdingLocationId)
   const itemVolume = sierraItem.fieldTag('v')[0]?.value
+  const itemPublisher = sierraBib?.varFieldsMulti([
+    { marc: '260', subfields: ['b', 'c'] },
+    { marc: '264', subfields: ['b', 'c'] }
+  ])
+    .map((match) => match.parallel?.value || match.value)
+    .map((s) => trimTrailingPunctuation(s))
+    .pop()
   const bib651 = sierraBib?.varField('651')
     .map((match) => match.value)
     .pop()
@@ -72,7 +79,7 @@ const aeonUrlForItem = async (esItem) => {
     ItemISxN: addSierraCheckDigit(itemUri),
     ItemNumber: firstValue(esItem.idBarcode()) || '',
     ItemPlace: firstValue(esItem.esBib?.placeOfPublication()) || '',
-    ItemPublisher: firstValue(esItem.esBib?.publisherLiteral()) || '',
+    ItemPublisher: itemPublisher,
     ItemVolume: itemVolume,
     Location: isReCAP ? 'ReCAP' : (locationLabel || ''),
     ReferenceNumber: addSierraCheckDigit(bibUri),

--- a/test/unit/utils-aeon-urls.test.js
+++ b/test/unit/utils-aeon-urls.test.js
@@ -68,7 +68,7 @@ describe('aeon-urls', () => {
       ItemISxN: 'i375287097',
       ItemNumber: '33433124443791',
       ItemPlace: 'New York',
-      ItemPublisher: 'Schomburg Center for Research in Black Culture',
+      ItemPublisher: 'Schomburg Center for Research in Black Culture, 2012.',
       ItemVolume: 'Disc 2',
       ReferenceNumber: 'b220279536',
       Site: 'SCHMIRS',
@@ -217,5 +217,20 @@ describe('aeon-urls', () => {
 
     const [, queryString] = url.split('?')
     expect(parseQueryString(queryString)['Transaction.CustomFields.SierraLocationCode']).to.be.a('undefined')
+  })
+
+  it('includes 260 $b in ItemPublisher', async () => {
+    const sierraItem = new SierraItem(require('../fixtures/item-37528709.json'))
+    const sierraBib = new SierraBib(require('../fixtures/bib-15088995.json'))
+    sierraItem._bibs = [sierraBib]
+
+    const esItem = new EsItem(sierraItem, new EsBib(sierraBib))
+
+    const url = await aeonUrlForItem(esItem)
+
+    const [, queryString] = url.split('?')
+    expect(parseQueryString(queryString).ItemPublisher).to.equal(
+      'Arte & História, 2000.'
+    )
   })
 })


### PR DESCRIPTION
Use 260 $bc and 264 $bc for Aeon ItemPublisher. (Previously ignored $c.)

https://jira.nypl.org/browse/SCC-4046