### PR TITLE
A few added fields for ES tuning

### DIFF
--- a/lib/elastic-search/index-schema.js
+++ b/lib/elastic-search/index-schema.js
@@ -92,13 +92,83 @@ exports.schema = () => ({
   carrierType: propertyTemplates.entity,
   carrierType_packed: propertyTemplates.packed,
   contentsTitle: propertyTemplates.fulltextFolded,
-  contributorLiteral: propertyTemplates.fulltextWithRawFolded,
+  contributorLiteral: {
+    type: 'text',
+    index: true,
+    fields: {
+      raw: {
+        type: 'keyword',
+        eager_global_ordinals: true
+      },
+      keywordLowercased: {
+        type: 'keyword',
+        normalizer: 'lowercase_normalizer'
+      },
+      folded: {
+        type: 'text',
+        analyzer: 'folding'
+      }
+    }
+  },
+  contributorLiteralNormalized: {
+    type: 'keyword',
+    fields: {
+      keywordLowercased: {
+        type: 'keyword',
+        normalizer: 'lowercase_normalizer'
+      }
+    }
+  },
+  contributorLiteralWithoutDates: {
+    type: 'keyword',
+    fields: {
+      keywordLowercased: {
+        type: 'keyword',
+        normalizer: 'lowercase_normalizer'
+      }
+    }
+  },
   contributor_sort: propertyTemplates.exactString,
   created: { type: 'date', index: false },
   createdDecade: propertyTemplates.number,
   createdString: propertyTemplates.exactString,
   createdYear: propertyTemplates.number,
-  creatorLiteral: propertyTemplates.fulltextWithRawFolded,
+  creatorLiteral: {
+    type: 'text',
+    index: true,
+    fields: {
+      raw: {
+        type: 'keyword',
+        eager_global_ordinals: true
+      },
+      keywordLowercased: {
+        type: 'keyword',
+        normalizer: 'lowercase_normalizer'
+      },
+      folded: {
+        type: 'text',
+        analyzer: 'folding'
+      }
+    }
+  },
+  creatorLiteralNormalized: {
+    type: 'keyword',
+    fields: {
+      keywordLowercased: {
+        type: 'keyword',
+        normalizer: 'lowercase_normalizer'
+      }
+    }
+  },
+  creatorLiteralWithoutDates: {
+    type: 'keyword',
+    fields: {
+      keywordLowercased: {
+        type: 'keyword',
+        normalizer: 'lowercase_normalizer'
+      }
+    }
+  },
   creator_sort: propertyTemplates.exactString,
   dateStartYear: propertyTemplates.number,
   description: propertyTemplates.fulltextFolded,

--- a/lib/elastic-search/requests.js
+++ b/lib/elastic-search/requests.js
@@ -111,6 +111,11 @@ const currentDocument = async (bibId, index) => {
     body: {
       query: { term: { uri: bibId } }
     }
+  }).catch((e) => {
+    if (e.statusCode === 403) {
+      logger.error(`403 from ES: ${e.body?.Message}`)
+    }
+    throw e
   })
   if (!response.body.hits.hits[0]) throw new Error(`Could not find ${bibId} in ${index}`)
   return response.body.hits.hits[0]._source

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -11,6 +11,7 @@ const { lookup } = require('../utils/lookup')
 const { getBibCallNum } = require('../utils/get-bib-call-num')
 const { unique, removeTrailingElementsMatching, sortByAsyncSortKey } = require('../utils')
 const { subjectLiteralFromSubfieldMap } = require('../utils/subject-formatter')
+const { normalizeAuthorName, withoutDates } = require('../utils/author-names')
 
 class EsBib extends EsBase {
   constructor (sierraBib) {
@@ -97,7 +98,35 @@ class EsBib extends EsBase {
   }
 
   contributorLiteral () {
-    return this._valueToIndexFromBasicMapping('contributorLiteral')
+    let contributorLiterals = this._valueToIndexFromBasicMapping('contributorLiteral')
+    if (!contributorLiterals) return null
+
+    // Filter out any contributors that also appear as creator:
+    const creators = this.creatorLiteral()
+    if (!creators) return contributorLiterals
+    contributorLiterals = contributorLiterals.filter((contrib) => {
+      // Contributor is redundant if there exists a creator of which the
+      // contributor is a prefix/match.
+      // E.g. contributor "Dickens, Charles" is redundant if there's a creator
+      // with "Dickens, Charles" or "Dickens, Charles, 1812-1870"
+      return !creators.find((creator) => creator.startsWith(contrib))
+    })
+
+    return contributorLiterals.length === 0 ? null : contributorLiterals
+  }
+
+  contributorLiteralNormalized () {
+    const names = this.contributorLiteral()
+    if (!names) return null
+
+    return names.map(normalizeAuthorName).flat()
+  }
+
+  contributorLiteralWithoutDates () {
+    const names = this.contributorLiteral()
+    if (!names) return null
+
+    return names.map(withoutDates)
   }
 
   contributor_sort () {
@@ -114,6 +143,20 @@ class EsBib extends EsBase {
 
   creatorLiteral () {
     return this._valueToIndexFromBasicMapping('creatorLiteral')
+  }
+
+  creatorLiteralNormalized () {
+    const names = this.creatorLiteral()
+    if (!names) return null
+
+    return names.map(normalizeAuthorName).flat()
+  }
+
+  creatorLiteralWithoutDates () {
+    const names = this.creatorLiteral()
+    if (!names) return null
+
+    return names.map(withoutDates)
   }
 
   creator_sort () {
@@ -515,6 +558,18 @@ class EsBib extends EsBase {
 
   placeOfPublication () {
     return this._valueToIndexFromBasicMapping('placeOfPublication')
+  }
+
+  async popularity () {
+    const items = await this.items()
+    return items.reduce((sum, item) => {
+      let checkouts = 0
+      const fixedValue = item.item.fixed('Total Checkouts')
+      if (fixedValue && parseInt(fixedValue)) {
+        checkouts = parseInt(fixedValue)
+      }
+      return sum + checkouts
+    }, 0)
   }
 
   publicationStatement () {

--- a/lib/utils/author-names.js
+++ b/lib/utils/author-names.js
@@ -1,0 +1,50 @@
+// Match the following patterns:
+//  - Lastname, (Firstname|Iniital.)
+//  - Lastname, (Firstname|Initial.) (Middlename|Initial.)
+const NAME_PATTERN = /^(?<last>[a-zÀ-ž-]+), (?<first>[a-zÀ-ž]\.|[a-zÀ-ž-]+)( (?<middle1>[a-zÀ-ž]\.|[a-zÀ-ž-]+))?( (?<middle2>[a-zÀ-ž]\.|[a-zÀ-ž-]+))?/i
+
+/**
+* Given a name such as appears in catalog data (e.g. "Smith, John A.", "John Smith Fdn."),
+* if the names matches NAME_PATTERHN above,
+* returns an array of possible normalizations (e.g. "John Smith", "John A. Smith")
+* Supports up to two middle name/initials.
+*/
+const normalizeAuthorName = (name) => {
+  // If name doesn't match, return it unchanged:
+  if (!NAME_PATTERN.test(name)) {
+    return [name]
+  }
+
+  const permutations = []
+
+  // Parse out name parts:
+  const parts = name.match(NAME_PATTERN)
+  const { first, last, middle1, middle2 } = parts.groups
+
+  // Start with firstname lastname
+  permutations.push(`${first} ${last}`)
+  // If there's a middle name, add that permutation:
+  if (middle1) {
+    permutations.push(`${first} ${middle1} ${last}`)
+    // If there's a second middle name, add that permutation:
+    if (middle2) {
+      permutations.push(`${first} ${middle1} ${middle2} ${last}`)
+    }
+  }
+
+  return permutations
+}
+
+const withoutDates = (name) => {
+  if (typeof name !== 'string') return name
+
+  const tokens = name.split(', ')
+  if (tokens.length < 3) return name
+
+  return tokens.slice(0, 2).join(', ')
+}
+
+module.exports = {
+  normalizeAuthorName,
+  withoutDates
+}

--- a/lib/utils/author-names.js
+++ b/lib/utils/author-names.js
@@ -43,14 +43,15 @@ const withoutDates = (name) => {
   if (typeof name !== 'string') return name
 
   const tokens = name.split(', ')
+    .slice(0, 2)
   if (tokens.length < 2) return name
 
-  // If author has only one name, last token may be dates; Remove it:
-  if (/\d{4}/.test(tokens[tokens.length - 1])) {
+  // If author has only one name, second token may be dates; Remove it:
+  if (/\d{4}/.test(tokens[1])) {
     tokens.pop()
   }
 
-  return tokens.slice(0, 2).join(', ')
+  return tokens.join(', ')
 }
 
 module.exports = {

--- a/lib/utils/author-names.js
+++ b/lib/utils/author-names.js
@@ -35,11 +35,20 @@ const normalizeAuthorName = (name) => {
   return permutations
 }
 
+/**
+* Given a author string (e.g. "Dickens, Charles, 1812-1870", "Gurudatta, 1894-1989"),
+* returns the string without the dates part of the string.
+*/
 const withoutDates = (name) => {
   if (typeof name !== 'string') return name
 
   const tokens = name.split(', ')
-  if (tokens.length < 3) return name
+  if (tokens.length < 2) return name
+
+  // If author has only one name, last token may be dates; Remove it:
+  if (/\d{4}/.test(tokens[tokens.length - 1])) {
+    tokens.pop()
+  }
 
   return tokens.slice(0, 2).join(', ')
 }

--- a/scripts/compare-with-indexed.js
+++ b/scripts/compare-with-indexed.js
@@ -14,7 +14,7 @@
 
 const argv = require('minimist')(process.argv.slice(2), {
   default: {
-    verbose: false,
+    verbose: true,
     printDocument: false
   },
   boolean: ['activeIndex', 'printDocument']
@@ -128,7 +128,7 @@ const run = async () => {
     const liveEsRecord = !bibUri
       ? null
       : await currentDocument(bibUri, indexName)
-        .catch((e) => console.log(`Could not find ${bibUri} in ${indexName}`))
+        .catch((e) => console.log(`Could not find ${bibUri} in ${indexName} (${e})`))
 
     // Would indexer delete it?
     if (recordsToDelete.length) {

--- a/test/unit/scripts-mapping-check.test.js
+++ b/test/unit/scripts-mapping-check.test.js
@@ -1,0 +1,113 @@
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('chai-as-promised'))
+const esClient = require('../../lib/elastic-search/client')
+
+const sinon = require('sinon')
+
+const mappingCheck = require('../../scripts/mapping-check')
+
+describe('scripts/mapping-check', () => {
+  const fakeMappings = {
+    prop1: {
+      type: 'keyword'
+    },
+    prop2: {
+      type: 'date'
+    },
+    prop3: {
+      type: 'text'
+    }
+  }
+
+  const fakeMappings2 = {
+    // Unchanged mapping:
+    prop2: {
+      type: 'date'
+    },
+    // Changed mapping:
+    prop3: {
+      type: 'keyword'
+    },
+    // New mapping:
+    prop4: {
+      type: 'keyword'
+    }
+  }
+
+  beforeEach(() => {
+    const getMapping = ({ index }) => {
+      return {
+        body: {
+          [index]: {
+            mappings: {
+              resource: { properties: fakeMappings }
+            }
+          }
+        }
+      }
+    }
+
+    sinon.stub(esClient, 'client').resolves({ indices: { getMapping } })
+  })
+
+  afterEach(() => {
+    esClient.client.restore()
+  })
+
+  describe('getMapping', () => {
+    it('gets a mapping', async () => {
+      const mapping = await mappingCheck.getMapping('some-index')
+      expect(mapping).to.deep.equal(fakeMappings)
+    })
+  })
+
+  describe('mappingsDiff', () => {
+    it('identifies differences', async () => {
+      expect(mappingCheck.mappingsDiff(fakeMappings, fakeMappings2)).to.deep.equal({
+        // Expect prop1 to be reported as local-only:
+        localOnlyMappings: [
+          { local: { type: 'keyword' }, property: 'prop1' }
+        ],
+        // Expect prop4 to be reported as a new remote mapping:
+        remoteOnlyMappings: [
+          { property: 'prop4', remote: { type: 'keyword' } }
+        ],
+        // Expect prop3 to appear as "unequal":
+        unequalMappings: [
+          {
+            local: { type: 'text' },
+            property: 'prop3',
+            remote: { type: 'keyword' }
+          }
+        ]
+      })
+    })
+  })
+
+  describe('run', () => {
+    const output = []
+
+    beforeEach(() => {
+      sinon.stub(global.console, 'log').callsFake((...args) => {
+        output.push(args)
+      })
+
+      sinon.stub(mappingCheck, 'currentSchema').callsFake(() => fakeMappings2)
+    })
+
+    afterEach(() => {
+      global.console.log.restore()
+      mappingCheck.currentSchema.restore()
+    })
+
+    it('reports on diffs', async () => {
+      await mappingCheck.run()
+
+      expect(output).to.have.lengthOf.above(15)
+      expect(output[0][0]).to.eq('Running mapping-check on indexName')
+      expect(output.find((log) => log[0].includes('Mis-mapped Properties'))).to.be.a('array')
+      expect(output.find((log) => log[0].includes('Missing (local-only) Propertie'))).to.be.a('array')
+    })
+  })
+})

--- a/test/unit/utils-author-names.test.js
+++ b/test/unit/utils-author-names.test.js
@@ -51,6 +51,8 @@ describe('utils/author-names', () => {
 
   describe('withoutDates', () => {
     it('removes dates from author string', () => {
+      expect(authorNamesUtils.withoutDates('Lastname'))
+        .to.equal('Lastname')
       expect(authorNamesUtils.withoutDates('Lastname, firstname'))
         .to.equal('Lastname, firstname')
       expect(authorNamesUtils.withoutDates('Lastname, firstname, 1979-2024'))
@@ -71,6 +73,8 @@ describe('utils/author-names', () => {
       expect(authorNamesUtils.withoutDates('Gurudatta, 1894-1989'))
         .to.equal('Gurudatta')
       expect(authorNamesUtils.withoutDates('Lastname, 1234'))
+        .to.equal('Lastname')
+      expect(authorNamesUtils.withoutDates('Lastname, 1234, other stuff'))
         .to.equal('Lastname')
       // We identify dates by 4 digits, so this isn't stripped:
       expect(authorNamesUtils.withoutDates('Lastname, 123'))

--- a/test/unit/utils-author-names.test.js
+++ b/test/unit/utils-author-names.test.js
@@ -62,7 +62,19 @@ describe('utils/author-names', () => {
       expect(authorNamesUtils.withoutDates('Louis XVI, King of France, 1754-1793.'))
         .to.equal('Louis XVI, King of France')
       expect(authorNamesUtils.withoutDates('Lastname-hyphenated, Firstname, 1979-'))
-        .to.deep.equal('Lastname-hyphenated, Firstname')
+        .to.equal('Lastname-hyphenated, Firstname')
+      // We say "dates", but really it's about stripping anything after the name:
+      expect(authorNamesUtils.withoutDates('Lastname, firstname, other stuff'))
+        .to.equal('Lastname, firstname')
+      // Support mononyms:
+      expect(authorNamesUtils.withoutDates('Cher, 1946-')).to.equal('Cher')
+      expect(authorNamesUtils.withoutDates('Gurudatta, 1894-1989'))
+        .to.equal('Gurudatta')
+      expect(authorNamesUtils.withoutDates('Lastname, 1234'))
+        .to.equal('Lastname')
+      // We identify dates by 4 digits, so this isn't stripped:
+      expect(authorNamesUtils.withoutDates('Lastname, 123'))
+        .to.equal('Lastname, 123')
     })
   })
 })

--- a/test/unit/utils-author-names.test.js
+++ b/test/unit/utils-author-names.test.js
@@ -1,0 +1,68 @@
+const expect = require('chai').expect
+
+const authorNamesUtils = require('../../lib/utils/author-names')
+
+describe('utils/author-names', () => {
+  describe('normalizeAuthorName', () => {
+    it('reverses a variety of author names', () => {
+      expect(authorNamesUtils.normalizeAuthorName('Lastname, Firstname'))
+        .to.deep.equal(['Firstname Lastname'])
+      expect(authorNamesUtils.normalizeAuthorName('Lastname, Firstname, 1979-'))
+        .to.deep.equal(['Firstname Lastname'])
+      expect(authorNamesUtils.normalizeAuthorName('Lastname-hyphenated, Firstname, 1979-'))
+        .to.deep.equal(['Firstname Lastname-hyphenated'])
+      expect(authorNamesUtils.normalizeAuthorName('Milne, A. A. (Alan Alexander), 1882-1956.'))
+        .to.deep.equal(['A. Milne', 'A. A. Milne'])
+      expect(authorNamesUtils.normalizeAuthorName('Milne, Alan A., 1882-1956.'))
+        .to.deep.equal(['Alan Milne', 'Alan A. Milne'])
+      expect(authorNamesUtils.normalizeAuthorName('Milne, A., 1882-1956.'))
+        .to.deep.equal(['A. Milne'])
+      expect(authorNamesUtils.normalizeAuthorName('Milne, AA, 1882-1956.'))
+        .to.deep.equal(['AA Milne'])
+      expect(authorNamesUtils.normalizeAuthorName('Milne, A A, 1882-1956.'))
+        .to.deep.equal(['A Milne', 'A A Milne'])
+      expect(authorNamesUtils.normalizeAuthorName('Mozart, Wolfgang Amadeus, 1756-1791'))
+        .to.deep.equal(['Wolfgang Mozart', 'Wolfgang Amadeus Mozart'])
+      expect(authorNamesUtils.normalizeAuthorName('Beethoven, Ludwig van, 1770-1827.'))
+        .to.deep.equal(['Ludwig Beethoven', 'Ludwig van Beethoven'])
+      expect(authorNamesUtils.normalizeAuthorName('Delibes, Léo, 1836-1891.'))
+        .to.deep.equal(['Léo Delibes'])
+
+      // No change to unsupported patterns:
+      expect(authorNamesUtils.normalizeAuthorName('Lastname')).to.deep.equal(['Lastname'])
+      expect(authorNamesUtils.normalizeAuthorName('Big long company name'))
+        .to.deep.equal(['Big long company name'])
+      expect(authorNamesUtils.normalizeAuthorName('Big long company name, with commas'))
+        .to.deep.equal(['Big long company name, with commas'])
+      expect(authorNamesUtils.normalizeAuthorName('Louis XVI, King of France, 1754-1793.'))
+        .to.deep.equal(['Louis XVI, King of France, 1754-1793.'])
+      expect(authorNamesUtils.normalizeAuthorName('Voltaire, 1694-1778.'))
+        .to.deep.equal(['Voltaire, 1694-1778.'])
+      expect(authorNamesUtils.normalizeAuthorName('Merce Cunningham Dance Foundation, donor.'))
+        .to.deep.equal(['Merce Cunningham Dance Foundation, donor.'])
+      expect(authorNamesUtils.normalizeAuthorName('WNYC (Radio station : New York, N.Y.)'))
+        .to.deep.equal(['WNYC (Radio station : New York, N.Y.)'])
+
+      // FIXME Unfortunately, we don't support this diacritic style for some reason:
+      expect(authorNamesUtils.normalizeAuthorName('Dvořák, Antonín, 1841-1904.'))
+        .to.deep.equal(['Dvořák, Antonín, 1841-1904.'])
+    })
+  })
+
+  describe('withoutDates', () => {
+    it('removes dates from author string', () => {
+      expect(authorNamesUtils.withoutDates('Lastname, firstname'))
+        .to.equal('Lastname, firstname')
+      expect(authorNamesUtils.withoutDates('Lastname, firstname, 1979-2024'))
+        .to.equal('Lastname, firstname')
+      expect(authorNamesUtils.withoutDates('Lastname, firstname m. m., 1979-2024'))
+        .to.equal('Lastname, firstname m. m.')
+      expect(authorNamesUtils.withoutDates('Dvořák, Antonín, 1841-1904.'))
+        .to.equal('Dvořák, Antonín')
+      expect(authorNamesUtils.withoutDates('Louis XVI, King of France, 1754-1793.'))
+        .to.equal('Louis XVI, King of France')
+      expect(authorNamesUtils.withoutDates('Lastname-hyphenated, Firstname, 1979-'))
+        .to.deep.equal('Lastname-hyphenated, Firstname')
+    })
+  })
+})


### PR DESCRIPTION
Adds a couple new ES fields to improve author matching.

Also fixes a couple minor things with bulk-index and compare-with-indexed scripts.

~This depends on Node20 updates, so targets that branch currently, but will be merged into `main` when which are now in `main` since [PR 89](https://github.com/NYPL/research-catalog-indexer/pull/89) is merged.~