### PR TITLE
Fix a few things uncovered in testing

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: 'npm'
       - name: Install dependencies
         run: npm i

--- a/lib/elastic-search/index-schema.js
+++ b/lib/elastic-search/index-schema.js
@@ -328,6 +328,7 @@ exports.schema = () => ({
   parallelPublisherLiteral: propertyTemplates.fulltextFolded,
   partOf: propertyTemplates.exactString,
   placeOfPublication: propertyTemplates.exactString,
+  popularity: propertyTemplates.number,
   publicDomain: propertyTemplates.boolean,
   publisherLiteral: propertyTemplates.fulltextWithRawFolded,
   publicationStatement: propertyTemplates.exactStringNotIndexed,

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -564,7 +564,7 @@ class EsBib extends EsBase {
     const items = await this.items()
     return items.reduce((sum, item) => {
       let checkouts = 0
-      const fixedValue = item.item.fixed('Total Checkouts')
+      const fixedValue = item.item?.fixed('Total Checkouts')
       if (fixedValue && parseInt(fixedValue)) {
         checkouts = parseInt(fixedValue)
       }

--- a/lib/platform-api/requests.js
+++ b/lib/platform-api/requests.js
@@ -127,7 +127,10 @@ const _itemsForOneBib = async (bib, offset = 0, limit = 500) => {
       return null
     }
   } catch (e) {
-    logger.error('PlatformApi#_itemsForOneBib error: ', e.message)
+    if (e.name === 'TokenRefreshError') {
+      throw e
+    }
+    logger.error('PlatformApi#_itemsForOneBib error: ', e.message, e)
   }
 }
 

--- a/provisioning/base/resources.tf
+++ b/provisioning/base/resources.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "lambda_instance" {
   handler       = "index.handler"
   memory_size   = 512
   role          = "arn:aws:iam::946183545209:role/lambda-full-access"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs20.x"
   timeout       = 300
 
   # Location of the zipped code in S3:

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -7,17 +7,18 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs20.x
       Timeout: 300
       Environment:
         Variables:
-          NYPL_API_BASE_URL: http://qa-platform.nypl.org/api/v0.1/
+          NYPL_API_BASE_URL: https://qa-platform.nypl.org/api/v0.1/
           NYPL_OAUTH_URL: https://isso.nypl.org/
           NYPL_OAUTH_KEY: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGswaQYJKoZIhvcNAQcGoFwwWgIBADBVBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDNQozUGkaz8WYD2lUAIBEIAo/SzNMA9LowO6gcnTUCcMjBaAU1RH/L3EAS14fjJCUpyZppkuEDUd7w==
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAxN3indXvk2ueiE6CwCARCAQ018FdIVXXwfTuKH1vp/ZTfjBinxKTDosMmzyWB9/CtiFtgOu09iiyZEpC3AyGOt8ExywHZoHOZQuLdGGNFgbusmldw=
-          ELASTICSEARCH_CONNECTION_URI: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAK8wgawGCSqGSIb3DQEHBqCBnjCBmwIBADCBlQYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAxrJio3oL3JETS6dNMCARCAaKtg+mvgbSkkLh6JiZ97c02ZH3gWpOBGD8vNadjl7p/SjS7aTtBjanWOfsXdwkEYq6s1SHwGtfwmSB4X6ExBYXDUDFWlmJ/FODtEvMoNXkD0ERXHGvxmSnWWbvh4sa+/QUOvMf9k5y5t
+          ELASTICSEARCH_CONNECTION_URI: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAALcwgbQGCSqGSIb3DQEHBqCBpjCBowIBADCBnQYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwLEPDqsqAvuJdR8ckCARCAcKo/xhIswLW0MazFXGYVn+qrAFMOTEOzUiMsLNAzHJ7n4Fi1AJztcQSHIOgizHZuDXM0ULUebUaES8mmOwsH8pxi30UmX5/rtTakE5/dbVKZN7yvzt7FsEMlhfhBbloTDK0HaQcdsnL2BcnwxztXRUQ=
           ELASTIC_RESOURCES_INDEX_NAME: research-catalog-indexer-test-index
           LOG_LEVEL: debug
           SCSB_URL: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAHwwegYJKoZIhvcNAQcGoG0wawIBADBmBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDEmr+dCcU7kP/Uf2iwIBEIA5vNcSLv4nFFSvgv92JUly6auPiuNlYeqkcSSLMRo77YQGkseDcsglOg2+0EOJhLu4ud6aSTxU+dri
           SCSB_API_KEY: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIMwgYAGCSqGSIb3DQEHBqBzMHECAQAwbAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAw8tglwVzGKBduDD9wCARCAP4biSz13FvZVHyQ8LKCb0+uLcKUKmzWqC5abVJI0kTmQJvjr9ViHsuP9/qj94Y8E7K96sb+fn0+HZk8So6CssA==
+          STREAM_ENVIRONMENT: qa
 


### PR DESCRIPTION
Fix a few minor things uncovered when validating qa deployment:
 - Use Node20 (not 18) everywhere
 - Note the new `popularity` property in the index-schema (mostly a formality)
 - Fix small runtime bug with checkin cards
 - Job should error hard when encountering unrecoverable platform api auth errors