### PR TITLE
Ensure contributor* fields don't duplicate creator*

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -121,22 +121,24 @@ class EsBib extends EsBase {
   * All distinct contributor names after "normalization" - `Firstname Lastname`
   */
   contributorLiteralNormalized () {
-    const names = this.contributorLiteral()
+    let names = this.contributorLiteral()
     if (!names) return null
 
-    return names.map(normalizeAuthorName)
+    names = names.map(normalizeAuthorName)
       .flat()
       // Remove any names that duplicate normalized creator names:
       .filter((contrib) => !nameIsRedundant(contrib, this.creatorLiteralNormalized()))
+    return names.length === 0 ? null : names
   }
 
   contributorLiteralWithoutDates () {
-    const names = this.contributorLiteral()
+    let names = this.contributorLiteral()
     if (!names) return null
 
-    return names.map(withoutDates)
+    names = names.map(withoutDates)
       // Remove any names that duplicate creator names w/out dates:
       .filter((contrib) => !nameIsRedundant(contrib, this.creatorLiteralWithoutDates()))
+    return names.length === 0 ? null : names
   }
 
   contributor_sort () {

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -108,10 +108,7 @@ class EsBib extends EsBase {
 
     contributorLiterals = contributorLiterals
       .map(trimTrailingPeriod)
-      // Contributor is redundant if there exists a creator of which the
-      // contributor is a prefix/match.
-      // E.g. contributor "Dickens, Charles" is redundant if there's a creator
-      // with "Dickens, Charles" or "Dickens, Charles, 1812-1870"
+      // Remove if redundant with respect to creator values:
       .filter((contrib) => !nameIsRedundant(contrib, this.creatorLiteral()))
 
     return contributorLiterals.length === 0 ? null : contributorLiterals

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -11,7 +11,12 @@ const { lookup } = require('../utils/lookup')
 const { getBibCallNum } = require('../utils/get-bib-call-num')
 const { unique, removeTrailingElementsMatching, sortByAsyncSortKey } = require('../utils')
 const { subjectLiteralFromSubfieldMap } = require('../utils/subject-formatter')
-const { normalizeAuthorName, withoutDates } = require('../utils/author-names')
+const {
+  normalizeAuthorName,
+  withoutDates,
+  nameIsRedundant,
+  trimTrailingPeriod
+} = require('../utils/author-names')
 
 class EsBib extends EsBase {
   constructor (sierraBib) {
@@ -101,25 +106,28 @@ class EsBib extends EsBase {
     let contributorLiterals = this._valueToIndexFromBasicMapping('contributorLiteral')
     if (!contributorLiterals) return null
 
-    // Filter out any contributors that also appear as creator:
-    const creators = this.creatorLiteral()
-    if (!creators) return contributorLiterals
-    contributorLiterals = contributorLiterals.filter((contrib) => {
+    contributorLiterals = contributorLiterals
+      .map(trimTrailingPeriod)
       // Contributor is redundant if there exists a creator of which the
       // contributor is a prefix/match.
       // E.g. contributor "Dickens, Charles" is redundant if there's a creator
       // with "Dickens, Charles" or "Dickens, Charles, 1812-1870"
-      return !creators.find((creator) => creator.startsWith(contrib))
-    })
+      .filter((contrib) => !nameIsRedundant(contrib, this.creatorLiteral()))
 
     return contributorLiterals.length === 0 ? null : contributorLiterals
   }
 
+  /*
+  * All distinct contributor names after "normalization" - `Firstname Lastname`
+  */
   contributorLiteralNormalized () {
     const names = this.contributorLiteral()
     if (!names) return null
 
-    return names.map(normalizeAuthorName).flat()
+    return names.map(normalizeAuthorName)
+      .flat()
+      // Remove any names that duplicate normalized creator names:
+      .filter((contrib) => !nameIsRedundant(contrib, this.creatorLiteralNormalized()))
   }
 
   contributorLiteralWithoutDates () {
@@ -127,6 +135,8 @@ class EsBib extends EsBase {
     if (!names) return null
 
     return names.map(withoutDates)
+      // Remove any names that duplicate creator names w/out dates:
+      .filter((contrib) => !nameIsRedundant(contrib, this.creatorLiteralWithoutDates()))
   }
 
   contributor_sort () {
@@ -142,7 +152,11 @@ class EsBib extends EsBase {
   }
 
   creatorLiteral () {
-    return this._valueToIndexFromBasicMapping('creatorLiteral')
+    const names = this._valueToIndexFromBasicMapping('creatorLiteral')
+    if (!names) return null
+
+    return names
+      .map(trimTrailingPeriod)
   }
 
   creatorLiteralNormalized () {

--- a/lib/utils/author-names.js
+++ b/lib/utils/author-names.js
@@ -54,7 +54,35 @@ const withoutDates = (name) => {
   return tokens.join(', ')
 }
 
+/**
+* Given a contributor name and a list of "other names", returns true if the name
+* essentially duplicates one of the "other names".
+*
+* e.g. nameIsRedundant (
+*        'Dickens, Charles',
+*        ['Doe, Jane', 'Dickens, Charles, 1812-1870']
+*      ) => true
+*/
+const nameIsRedundant = (name, otherNames) => {
+  if (!otherNames) return false
+
+  return otherNames.some((otherName) => otherName.startsWith(name))
+}
+
+/**
+* Given a name string (e.g. "Dickens, Charles", "Doe, Jane.", returns same
+* string with meaningless trailing period character removed. Only removes
+* trailing period if it follows 2 or more lowercase characters - to avoid
+* removing periods after an initial.
+*/
+const trimTrailingPeriod = (name) => {
+  if (!name) return name
+  return name.replace(/(?<=[a-z]{2})\.$/, '')
+}
+
 module.exports = {
+  nameIsRedundant,
   normalizeAuthorName,
+  trimTrailingPeriod,
   withoutDates
 }

--- a/test/fixtures/bib-10027451.json
+++ b/test/fixtures/bib-10027451.json
@@ -1,0 +1,488 @@
+{
+  "id": "10027451",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2021-11-05T04:39:33-04:00",
+  "createdDate": "2008-12-13T16:19:48-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": [
+    {
+      "code": "mal",
+      "name": "SASB - Service Desk Rm 315"
+    }
+  ],
+  "suppressed": false,
+  "lang": {
+    "code": "fre",
+    "name": "French"
+  },
+  "title": "La petite Dorrit. Un conte de deux villes. Volume publié sous la direction de Pierre Leyris. [Traduction par Jeanne Métifeu-Béjeau.",
+  "author": "Dickens, Charles, 1812-1870.",
+  "materialType": {
+    "code": "a  ",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 1970,
+  "catalogDate": "2000-10-03",
+  "country": {
+    "code": "fr ",
+    "name": "France"
+  },
+  "normTitle": "la petite dorrit un conte de deux villes volume publié sous la direction de pierre leyris traduction par jeanne métifeu béjeau",
+  "normAuthor": "dickens charles 1812 1870",
+  "standardNumbers": [],
+  "controlNumber": "NYPG710120089-B",
+  "fixedFields": {
+    "24": {
+      "label": "Language",
+      "value": "fre",
+      "display": "French"
+    },
+    "25": {
+      "label": "Skip",
+      "value": "3",
+      "display": null
+    },
+    "26": {
+      "label": "Location",
+      "value": "mal  ",
+      "display": "SASB - Service Desk Rm 315"
+    },
+    "27": {
+      "label": "COPIES",
+      "value": "1",
+      "display": null
+    },
+    "28": {
+      "label": "Cat. Date",
+      "value": "2000-10-03",
+      "display": null
+    },
+    "29": {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    "30": {
+      "label": "Material Type",
+      "value": "a  ",
+      "display": "BOOK/TEXT"
+    },
+    "31": {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": null
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "b",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "10027451",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2008-12-13T16:19:48Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2021-11-05T04:39:33Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "7",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "89": {
+      "label": "Country",
+      "value": "fr ",
+      "display": "France"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2021-10-17T04:13:31Z",
+      "display": null
+    },
+    "107": {
+      "label": "MARC Type",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "a",
+      "marcTag": "100",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Dickens, Charles,"
+        },
+        {
+          "tag": "d",
+          "content": "1812-1870."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Leyris, Pierre."
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": "700",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Dickens, Charles,"
+        },
+        {
+          "tag": "d",
+          "content": "1812-1870."
+        },
+        {
+          "tag": "t",
+          "content": "Conte de deux villes."
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "010",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "70499072"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "NN710120089"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "(WaOLN)nyp0027559"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Translations of Little Dorrit and A tale of two cities."
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "\"Note bibliographique\": p. [1367]"
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "NYPG710120089-B",
+      "subfields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Paris]"
+        },
+        {
+          "tag": "b",
+          "content": "Gallimard"
+        },
+        {
+          "tag": "c",
+          "content": "[1970]"
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "JFC 71-49"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "xvi, 1374 p."
+        },
+        {
+          "tag": "c",
+          "content": "18 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": "s",
+      "marcTag": "490",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Bibliothèque de la Pléiade,"
+        },
+        {
+          "tag": "v",
+          "content": "216"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "1",
+      "ind2": "3",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "La petite Dorrit."
+        },
+        {
+          "tag": "b",
+          "content": "Un conte de deux villes. Volume publié sous la direction de Pierre Leyris. [Traduction par Jeanne Métifeu-Béjeau."
+        }
+      ]
+    },
+    {
+      "fieldTag": "u",
+      "marcTag": "740",
+      "ind1": "3",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Un conte de deux villes."
+        }
+      ]
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": "959",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": ".b10278709"
+        },
+        {
+          "tag": "b",
+          "content": "07-18-08"
+        },
+        {
+          "tag": "c",
+          "content": "07-29-91"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20000629165208.0",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "710216s1970    fr            00| 1|fre| cam   ",
+      "subfields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "c",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "WaOLN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "041",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "fre"
+        },
+        {
+          "tag": "h",
+          "content": "eng"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "997",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "hg"
+        },
+        {
+          "tag": "b",
+          "content": "10-03-00"
+        },
+        {
+          "tag": "c",
+          "content": "m"
+        },
+        {
+          "tag": "d",
+          "content": "a"
+        },
+        {
+          "tag": "e",
+          "content": "-"
+        },
+        {
+          "tag": "f",
+          "content": "fre"
+        },
+        {
+          "tag": "g",
+          "content": "fr "
+        },
+        {
+          "tag": "h",
+          "content": "3"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "910",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "RL"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cam  2200277   4500",
+      "subfields": null
+    }
+  ]
+}

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -76,7 +76,7 @@ describe('EsBib', function () {
     it('should return the creator literal', function () {
       const record = new SierraBib(require('../fixtures/bib-10001936.json'))
       const esBib = new EsBib(record)
-      expect(esBib.creatorLiteral()).to.deep.equal(['Shermazanian, Galust.'])
+      expect(esBib.creatorLiteral()).to.deep.equal(['Shermazanian, Galust'])
     })
   })
 
@@ -98,7 +98,7 @@ describe('EsBib', function () {
     it('should return the creator transformed for sorting', () => {
       const record = new SierraBib(require('../fixtures/bib-10001936.json'))
       const esBib = new EsBib(record)
-      expect(esBib.creator_sort()).to.deep.equal(['shermazanian, galust.'])
+      expect(esBib.creator_sort()).to.deep.equal(['shermazanian, galust'])
     })
   })
 
@@ -289,6 +289,16 @@ describe('EsBib', function () {
       const esBib = new EsBib(record)
       expect(esBib.contributorLiteralWithoutDates()).to.deep.equal([
         'Ginosar, Sh. (Shaleṿ)'
+      ])
+    })
+
+    it('should remove contributorLiteralWithoutDates that duplicate creatorLiteralWithoutDates', function () {
+      const record = new SierraBib(require('../fixtures/bib-10027451.json'))
+      const esBib = new EsBib(record)
+      // This bib has a 700 with "Dickens, Charles", but it duplicates a 100,
+      // so we don't want to see it repeated in this field:
+      expect(esBib.contributorLiteralWithoutDates()).to.deep.equal([
+        'Leyris, Pierre'
       ])
     })
   })

--- a/test/unit/utils-author-names.test.js
+++ b/test/unit/utils-author-names.test.js
@@ -81,4 +81,39 @@ describe('utils/author-names', () => {
         .to.equal('Lastname, 123')
     })
   })
+
+  describe('nameIsRedundant', () => {
+    it('returns true if name is redundant', () => {
+      const names = ['Doe, Jane', 'Dickens, Charles, 1812-1870']
+
+      expect(authorNamesUtils.nameIsRedundant('Dickens, Charles', names))
+        .to.equal(true)
+      expect(authorNamesUtils.nameIsRedundant('Doe, Jane', names))
+        .to.equal(true)
+    })
+
+    it('returns false if name is not matched', () => {
+      const names = ['Doe, Jane', 'Dickens, Charles, 1812-1870']
+
+      expect(authorNamesUtils.nameIsRedundant('Dickens, Charlesregard', names))
+        .to.equal(false)
+      expect(authorNamesUtils.nameIsRedundant('Shelley, Mary', names))
+        .to.equal(false)
+    })
+  })
+
+  describe('trimTrailingPeriod', () => {
+    it('removes trailing period', () => {
+      expect(authorNamesUtils.trimTrailingPeriod('Doe, Jane'))
+        .to.equal('Doe, Jane')
+      expect(authorNamesUtils.trimTrailingPeriod('Doe, Jane.'))
+        .to.equal('Doe, Jane')
+
+      // Assert meaningful periods not removed:
+      expect(authorNamesUtils.trimTrailingPeriod('Michael K.'))
+        .to.equal('Michael K.')
+      expect(authorNamesUtils.trimTrailingPeriod('Michael k.'))
+        .to.equal('Michael k.')
+    })
+  })
 })


### PR DESCRIPTION
Updates contributorLiteralNormalized and contributorLiteralWithoutDates fields to remove entries that are found to duplicate creator* fields.

This is to ensure we don’t ever have a bib with, for example, creatorLiteralNormalized "Charles Dickens" and contributorLiteralNormalized "Charles Dickens" due to the two different Charles's being named in different roles, which would unfairly boost this record when matching on both of those Normalized fields.

Also adds removal of trailing period characters in creator and contributor fields so that we don't ever index e.g. "Dickens, Charles.".

https://newyorkpubliclibrary.atlassian.net/browse/SCC-4278