### PR TITLE
Add EsBib.buildingLocationIds

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -23,6 +23,24 @@ class EsBib extends EsBase {
     return this._valueToIndexFromBasicMapping('addedAuthorTitle')
   }
 
+  /**
+  * Set of distinct research center location ids, e.g. ['rc', 'ma']
+  */
+  async buildingLocationIds () {
+    const items = await this.items()
+    return unique(
+      items
+        // Filter on items with a holdingLocation:
+        .filter((item) => item.holdingLocation() && item.holdingLocation().length)
+        // Translate holdingLocation into plain id:
+        .map((item) => item.holdingLocation()[0].id.split(':').pop())
+        // Translate into parent id:
+        .map((locationId) => locationId.substring(0, 2))
+        // Restrict to known Research parent locations:
+        .filter((id) => ['ma', 'pa', 'sc', 'rc'].includes(id))
+    )
+  }
+
   carrierType () {
     // construct a suitable return object for the given fallback carriertype:
     const useDefault = function (id) {

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1322,4 +1322,26 @@ describe('EsBib', function () {
       expect(await bib.popularity()).to.deep.equal(4)
     })
   })
+
+  describe('buildingLocationIds', () => {
+    it('builds array of plain, distinct building ids from item locations', async () => {
+      const bib = new SierraBib(require('../fixtures/bib-10001936.json'))
+      bib._items = []
+      // Adopt a RC items:
+      bib._items.push(new SierraItem(require('../fixtures/item-10003973.json')))
+      expect(await (new EsBib(bib)).buildingLocationIds()).to.deep.equal(['rc'])
+
+      // Adopt another RC items:
+      bib._items.push(new SierraItem(require('../fixtures/item-17145801.json')))
+      expect(await (new EsBib(bib)).buildingLocationIds()).to.deep.equal(['rc'])
+
+      // Adopt a Maps items:
+      bib._items.push(new SierraItem(require('../fixtures/item-14441624.json')))
+      expect(await (new EsBib(bib)).buildingLocationIds()).to.deep.equal(['ma', 'rc'])
+
+      // Replace with a single SC item:
+      bib._items = [new SierraItem(require('../fixtures/item-37528709.json'))]
+      expect(await (new EsBib(bib)).buildingLocationIds()).to.deep.equal(['sc'])
+    })
+  })
 })


### PR DESCRIPTION
Being an array of distinct parent location ids for the bib's items, so that we can boost on-site materials and filter by research center.

https://newyorkpubliclibrary.atlassian.net/browse/SCC-4279