### PR TITLE
[SCC-4455] Support multiple 910|a fields

### DIFF
--- a/lib/sierra-models/bib.js
+++ b/lib/sierra-models/bib.js
@@ -35,9 +35,9 @@ class SierraBib extends SierraBase {
     // https://github.com/NYPL/nypl-core/blob/master/vocabularies/csv/locations.csv#L2265
     const hasOtfLocation = this.locations && this.locations[0] && this.locations[0].code === 'os'
 
-    // Having 910 $a === 'RLOTF' is also a solid indicator introduced in OTF
+    // Having 910 $a contain 'RLOTF' is also a solid indicator introduced in OTF
     // record creation Oct 2021 https://github.com/NYPL/recap-hold-request-consumer/pull/33
-    const hasOtf910 = this._varField910() === 'RLOTF'
+    const hasOtf910 = this._varField910().includes('RLOTF')
 
     return hasOtfLocation || hasOtf910
   }
@@ -70,10 +70,10 @@ class SierraBib extends SierraBase {
     }
 
     // Check 910 $a for RL or BL:
-    const researchBranchFlag = this._varField910()
-    if (researchBranchFlag) {
-      const isResearch = ['RL', 'RLOTF'].includes(researchBranchFlag)
-      return { isResearch, rationale: `910 $a is ${researchBranchFlag}` }
+    const researchBranchFlags = this._varField910()
+    if (researchBranchFlags.length !== 0) {
+      const isResearch = researchBranchFlags.includes('RL') || researchBranchFlags.includes('RLOTF')
+      return { isResearch, rationale: `910 $a is ${researchBranchFlags}` }
     }
 
     // If bib has Research locations, it's Research
@@ -103,14 +103,14 @@ class SierraBib extends SierraBase {
   }
 
   /**
-   *  Get the value in 910 $a if one exists.
+   *  Get the values in 910 $a.
    *
-   *  This value typically has RL for Research bibs, BL for Branch bibs, or
+   *  These values typically are RL for Research bibs, BL for Branch bibs, or
    *  RLOTF for OTF (Research) bibs
    */
   _varField910 () {
     const varField = this.varField('910', ['a'])
-    return Array.isArray(varField) ? varField[0]?.value : null
+    return Array.isArray(varField) ? varField.map(field => field.value) : []
   }
 
   /**

--- a/test/fixtures/bib-11606020.json
+++ b/test/fixtures/bib-11606020.json
@@ -560,6 +560,19 @@
       "subfields": [
         {
           "tag": "a",
+          "content": "BL"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "910",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
           "content": "RL"
         }
       ]


### PR DESCRIPTION
See https://newyorkpubliclibrary.atlassian.net/browse/SCC-4455 - this change adds support for checking multiple `910|a` values for whether a bib/item is meant for research, instead of just the first value in the field.

#### Testing
* Updated tests to include a fixture with both `BL` and `RL` in the `910|a` field.