### PR TITLE
Stop adding fieldtag v to shelfMark

### DIFF
--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -233,22 +233,9 @@ class EsItem extends EsBase {
   }
 
   // ToDO: getting callnum from bib
-  shelfMark (addVolume = true) {
-    let callnum = this._callNum()
-    // If not found in var field
-    if (callnum) {
-      if (addVolume) {
-        // Pull callnumber suffix from fieldTag v if present
-        const callnumSuffix = this.item.fieldTag('v')[0]?.value
-
-        if (callnumSuffix) {
-          callnum += ' ' + callnumSuffix
-        }
-      }
-
-      // Finally store the complete shelfMark data
-      return [callnum]
-    }
+  shelfMark () {
+    const callnum = this._callNum()
+    return callnum ? [callnum] : null
   }
 
   shelfMark_sort () {

--- a/test/unit/es-item.test.js
+++ b/test/unit/es-item.test.js
@@ -141,7 +141,7 @@ describe('EsItem', function () {
         const record = new SierraItem(require('../fixtures/item-17145801.json'))
         const esItem = new EsItem(record)
         expect(esItem.identifier()).to.deep.equal([
-          'urn:shelfmark:*DM (Esprit des Journaux, françois et etrangers) no. 12 (1784)',
+          'urn:shelfmark:*DM (Esprit des Journaux, françois et etrangers)',
           'urn:barcode:33433081745998'
         ])
       })
@@ -156,7 +156,7 @@ describe('EsItem', function () {
         expect(esItem.identifierV2()).to.deep.equal(
           [
             {
-              value: '*DM (Esprit des Journaux, françois et etrangers) no. 12 (1784)',
+              value: '*DM (Esprit des Journaux, françois et etrangers)',
               type: 'bf:ShelfMark'
             },
             {
@@ -176,7 +176,7 @@ describe('EsItem', function () {
         const esItem = new EsItem(record)
         expect(esItem.shelfMark()).to.deep.equal(
           [
-            '*DM (Esprit des Journaux, françois et etrangers) no. 12 (1784)'
+            '*DM (Esprit des Journaux, françois et etrangers)'
           ]
         )
       })
@@ -190,7 +190,7 @@ describe('EsItem', function () {
         const esItem = new EsItem(record)
         const v = await esItem.shelfMark_sort()
         expect(v).to.equal(
-          'a*DM (Esprit des Journaux, françois et etrangers) no. 000012 (1784)'
+          'a*DM (Esprit des Journaux, françois et etrangers)'
         )
       })
     })


### PR DESCRIPTION
By popular demand, stop adding fieldtag v to shelfmark.

https://newyorkpubliclibrary.atlassian.net/browse/SCC-4590