### PR TITLE
add 590 to notes mappng

### DIFF
--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -847,6 +847,13 @@
           "a"
         ],
         "description": "Source of Description"
+      },
+      {
+        "marc": "590",
+        "subfields": [
+          "a"
+        ],
+        "description": "Local note"
       }
     ]
   },


### PR DESCRIPTION
https://newyorkpubliclibrary.atlassian.net/browse/SCC-3302

Add 590 to note mapping array. The ticket goes into a lot about public/private notes, but [RCI already has logic](https://github.com/NYPL/research-catalog-indexer/blob/main/lib/es-models/bib.js) to filter out notes with ind1 === 0 in _buildNotesArray. I believe this is all that is required to fulfill the AC for this ticket.