### PR TITLE
Slightly different check for skipping the inner-select

### DIFF
--- a/scripts/bulk-index.js
+++ b/scripts/bulk-index.js
@@ -437,15 +437,15 @@ const buildSqlQuery = (options) => {
   // Determine whether or not to use an inner-select to de-dupe the records:
   const dedupe = !!options.hasMarc
 
-  // Some queries will return bibs multiple times because a matched var/subfield repeats.
-  // To ensure we only handle such bibs once, we must de-deupe the results on id & nypl_source.
-  // We use an inner-select to identify all of the distinct bibs (by id and nypl_source)
-  // which we then JOIN to retrieve all fields.
   const primaryColumns = dedupe ? 'DISTINCT id, nypl_source' : '*'
   let query = `SELECT ${primaryColumns} FROM ${sqlFromAndWhere}` +
     (options.orderBy ? ` ORDER BY ${options.orderBy}` : '') +
     (options.limit ? ` LIMIT ${options.limit}` : '') +
     (options.offset ? ` OFFSET ${options.offset}` : '')
+  // Some queries will return bibs multiple times because a matched var/subfield repeats.
+  // To ensure we only handle such bibs once, we must de-deupe the results on id & nypl_source.
+  // We use an inner-select to identify all of the distinct bibs (by id and nypl_source)
+  // which we then JOIN to retrieve all fields.
   if (dedupe) {
     query = 'SELECT R.*' +
       ` FROM (\n${query}\n) _R` +

--- a/scripts/bulk-index.js
+++ b/scripts/bulk-index.js
@@ -61,6 +61,7 @@
  *      batchSize {int}: How many records to index at one time. Default 100
  *      dryrun {boolean}: Set to true to perform all work, but skip writing to index.
  *      envfile {string}: Path to local .env file. Default ./config/qa-bulk-index.env
+ *      table {string}: Override primary table name used (e.g. bib_v2)
  *
  */
 const fs = require('fs')
@@ -433,24 +434,22 @@ const buildSqlQuery = (options) => {
     throw new Error('Insufficient options to buildSqlQuery')
   }
 
-  let query = `SELECT * FROM ${sqlFromAndWhere}` +
+  // Determine whether or not to use an inner-select to de-dupe the records:
+  const dedupe = !!options.hasMarc
+
+  // Some queries will return bibs multiple times because a matched var/subfield repeats.
+  // To ensure we only handle such bibs once, we must de-deupe the results on id & nypl_source.
+  // We use an inner-select to identify all of the distinct bibs (by id and nypl_source)
+  // which we then JOIN to retrieve all fields.
+  const primaryColumns = dedupe ? 'DISTINCT id, nypl_source' : '*'
+  let query = `SELECT ${primaryColumns} FROM ${sqlFromAndWhere}` +
     (options.orderBy ? ` ORDER BY ${options.orderBy}` : '') +
     (options.limit ? ` LIMIT ${options.limit}` : '') +
     (options.offset ? ` OFFSET ${options.offset}` : '')
-
-  if (!options.fromDate) {
-    // Some queries will return bibs multiple times because a matched var/subfield repeats.
-    // To ensure we only handle such bibs once, we must de-deupe the results on id & nypl_source.
-    // We use an inner-select to identify all of the distinct bibs (by id and nypl_source)
-    // which we then JOIN to retrieve all fields.
-    const innerSelect = `SELECT DISTINCT id, nypl_source FROM ${sqlFromAndWhere}` +
-      (options.orderBy ? ` ORDER BY ${options.orderBy}` : '') +
-      (options.limit ? ` LIMIT ${options.limit}` : '') +
-      (options.offset ? ` OFFSET ${options.offset}` : '')
-
+  if (dedupe) {
     query = 'SELECT R.*' +
-      ` FROM (\n${innerSelect}\n) _R` +
-      ` INNER JOIN ${table} R ON _R.id=R.id AND _R.nypl_source=R.nypl_source`
+      ` FROM (\n${query}\n) _R` +
+      ` INNER JOIN ${type} R ON _R.id=R.id AND _R.nypl_source=R.nypl_source`
   }
 
   return { query, params, type }

--- a/test/unit/scripts-bulk-index.test.js
+++ b/test/unit/scripts-bulk-index.test.js
@@ -17,7 +17,7 @@ const removeDupeWhitespace = (sql) => {
 // Map anticipated SQL queries to mocked data to return:
 const pgFixtures = [
   {
-    match: /SELECT R\.\* FROM \(SELECT DISTINCT id, nypl_source FROM bib WHERE nypl_source = \$1 AND id IN \('1234','5678'\) LIMIT 2\) _R INNER JOIN bib R ON _R\.id=R\.id AND _R\.nypl_source=R\.nypl_source/,
+    match: /SELECT \* FROM bib WHERE nypl_source = \$1 AND id IN \('1234','5678'\) LIMIT 2/,
     rows: [
       {
         id: 1234,
@@ -199,11 +199,9 @@ describe('scripts/bulk-index', () => {
       expect(bulkIndexer.buildSqlQuery({ bibId: '1234', nyplSource: 'sierra-nypl' }))
         .to.deep.eq({
           query: [
-            'SELECT R.* FROM (',
-            'SELECT DISTINCT id, nypl_source FROM bib',
+            'SELECT * FROM bib',
             '      WHERE nypl_source = $1',
-            '      AND id = $2 LIMIT 1',
-            ') _R INNER JOIN bib R ON _R.id=R.id AND _R.nypl_source=R.nypl_source'
+            '      AND id = $2 LIMIT 1'
           ].join('\n'),
           params: ['sierra-nypl', '1234'],
           type: 'bib'
@@ -214,11 +212,9 @@ describe('scripts/bulk-index', () => {
       expect(bulkIndexer.buildSqlQuery({ ids: ['1234'], nyplSource: 'some-source', type: 'table_name' }))
         .to.deep.eq({
           query: [
-            'SELECT R.* FROM (',
-            'SELECT DISTINCT id, nypl_source FROM table_name',
+            'SELECT * FROM table_name',
             '      WHERE nypl_source = $1',
-            "      AND id IN ('1234') LIMIT 1",
-            ') _R INNER JOIN table_name R ON _R.id=R.id AND _R.nypl_source=R.nypl_source'
+            "      AND id IN ('1234') LIMIT 1"
           ].join('\n'),
           params: ['some-source'],
           type: 'table_name'
@@ -245,9 +241,7 @@ describe('scripts/bulk-index', () => {
       expect(bulkIndexer.buildSqlQuery({ type: 'table_name' }))
         .to.deep.eq({
           query: [
-            'SELECT R.* FROM (',
-            'SELECT DISTINCT id, nypl_source FROM table_name',
-            ') _R INNER JOIN table_name R ON _R.id=R.id AND _R.nypl_source=R.nypl_source'
+            'SELECT * FROM table_name'
           ].join('\n'),
           params: [],
           type: 'table_name'


### PR DESCRIPTION
The thing that should trigger the inner-select is querying by repeatable fields (i.e. `hasMarc`). For everything else, we don't need the inner-select