### PR TITLE
filter non research;add source prefix for subjects

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,9 +44,6 @@ const processRecords = async (type, records, options = {}) => {
   const recordsToIndex = await buildEsDocument(filteredBibs)
 
   const messages = []
-  if (type === 'Bib') {
-    await emitBibSubjectEvents([...filteredBibs, ...removedBibs])
-  }
 
   if (recordsToIndex.length) {
     if (options.dryrun) {
@@ -72,6 +69,10 @@ const processRecords = async (type, records, options = {}) => {
     }
 
     messages.push(`Deleted ${recordsToDelete.length} doc(s)`)
+  }
+
+  if (type === 'Bib') {
+    await emitBibSubjectEvents([...filteredBibs, ...removedBibs])
   }
 
   const message = messages.length ? messages.join('; ') : 'Nothing to do.'

--- a/lib/browse-terms/index.js
+++ b/lib/browse-terms/index.js
@@ -43,9 +43,10 @@ const getPrimaryAndParallelLabels = (subjectVarfieldObject) => {
   return labels
 }
 
-const getSubjectModels = (sierraRecord) => {
-  const marcTags = BibMappings.get('subjectLiteral', sierraRecord)
-  return sierraRecord.varFieldsMulti(marcTags, true).map(getPrimaryAndParallelLabels).map((subject) => ({ ...subject, sourceId: sierraRecord.id }))
+const getSubjectModels = async (esRecord) => {
+  const marcTags = BibMappings.get('subjectLiteral', esRecord.bib)
+  const id = await esRecord.uri()
+  return esRecord.bib.varFieldsMulti(marcTags, true).map(getPrimaryAndParallelLabels).map((subject) => ({ ...subject, sourceId: id }))
 }
 /**
  *
@@ -60,14 +61,16 @@ const getSubjectModels = (sierraRecord) => {
  */
 const buildBibSubjectEvents = async (sierraRecords) => {
   // use built in esBib logic to parse nyplSource and build uri with prefix
-  const esRecords = sierraRecords.map((record) => new EsBib(record))
+  const esRecords = sierraRecords
+    .filter((record) => record.getIsResearchWithRationale().isResearch)
+    .map((record) => new EsBib(record))
   const idsToFetch = await Promise.all(esRecords.map(async (record) => {
     const uri = await record.uri()
     return uri
   }))
   const staleSubjectLiterals = await fetchStaleSubjectLiterals(idsToFetch)
   const staleSubjectObjects = staleSubjectLiterals.map(subject => ({ preferredTerm: subject }))
-  const freshSubjectObjects = sierraRecords.map(getSubjectModels).flat()
+  const freshSubjectObjects = (await Promise.all(esRecords.map(getSubjectModels))).flat()
   const updateTerms = [...staleSubjectObjects, ...freshSubjectObjects]
   logger.debug(`buildBibSubjectEvents: ${buildSubjectDiff(freshSubjectObjects, staleSubjectObjects).length} subjects actually need updated counts out of ${updateTerms.length} subject update objects generated`)
   return updateTerms


### PR DESCRIPTION
- filter out non research bibs from bib subject parsing activity
- add bib id prefix to sourceId
- move subject parsing to after RCI bib deletions happen. I don't think this makes a huge difference, but an effort to ensure that subject bib counts are definitely made after bibs are deleted.