### PR TITLE
rely on trim from browse-terms

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -1016,7 +1016,7 @@ class EsBib extends EsBase {
     }).filter(x => x)
     const values = removeTrailingElementsMatching(
       subjectLiterals, (s) => s === ''
-    ).map(subjectLiteral => subjectLiteral.trim())
+    )
 
     return values.length ? values : null
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-kms": "^3.226.0",
         "@aws-sdk/client-sqs": "^3.835.0",
         "@elastic/elasticsearch": "~7.12.0",
-        "@nypl/browse-term": "^0.2.0",
+        "@nypl/browse-term": "^0.2.1",
         "@nypl/nypl-core-objects": "^2.1.1",
         "@nypl/nypl-data-api-client": "^2.0.0",
         "@nypl/nypl-streams-client": "^2.0.0",
@@ -7464,9 +7464,10 @@
       }
     },
     "node_modules/@nypl/browse-term": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@nypl/browse-term/-/browse-term-0.2.0.tgz",
-      "integrity": "sha512-mfOVEL9hgmZm1Pst7Gy3h4Clob6zEzpUJFGVYFmES4yViAtvIGo/UPnWzLt5b06PmPO6/T+x+LKM7nR4FziPHQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@nypl/browse-term/-/browse-term-0.2.1.tgz",
+      "integrity": "sha512-sam3fvTXN+chxTFNyHDAuKCEzmh3VY8jSV6hCaoXXExEkP78XvRulVjfjOGjW89VQVqoJC10Nl13CjIsQjh3ZQ==",
+      "license": "ISC",
       "dependencies": {
         "winston": "^3.17.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-kms": "^3.226.0",
     "@aws-sdk/client-sqs": "^3.835.0",
     "@elastic/elasticsearch": "~7.12.0",
-    "@nypl/browse-term": "^0.2.0",
+    "@nypl/browse-term": "^0.2.1",
     "@nypl/nypl-core-objects": "^2.1.1",
     "@nypl/nypl-data-api-client": "^2.0.0",
     "@nypl/nypl-streams-client": "^2.0.0",


### PR DESCRIPTION
Use updated browse term package to trim whitespace, and remove it from the RCI