### PR TITLE
add box to enumeration chronology parsing

### DIFF
--- a/lib/utils/volume-parse.js
+++ b/lib/utils/volume-parse.js
@@ -35,6 +35,7 @@ exports.parseVolume = (fieldTagV) => {
 
 const extractVols = (matches) => {
   return matches.reduce((vols, match) => {
+    const isABox = match[0] && match[0].toLowerCase().includes('box')
     // catch matches on last regex (for a fieldtag v like '23'),
     // but not for strings that don't have obvious volume info
     if (matches.length === 1 && !match[1]) {
@@ -49,10 +50,10 @@ const extractVols = (matches) => {
       .map((m) => parseInt(m, 10))
       // Ensure values are within ES int ( https://www.elastic.co/guide/en/elasticsearch/reference/5.3/number.html )
       .filter((num) => Math.abs(num) <= Math.pow(2, 31) - 1)
-
     // [6,7,8] ==> [6,8]
     if (match.length > 2) match = [match[0], match[match.length - 1]]
     if (match.length === 1) match = [match[0], match[0]]
+    if (isABox) match = match.map((n) => 10000 - n)
     return [...vols, match]
   }, [])
 }

--- a/lib/utils/volume-parse.js
+++ b/lib/utils/volume-parse.js
@@ -13,6 +13,7 @@ exports.parseVolume = (fieldTagV) => {
     /(?:^|\s|-)(?:reel|r\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:^|\s|-)(?:no\.?)\s?(\d*)[-|/]?(\d*)?/gi,
     /(?:jaarg\.?)\s?(\d*)[-|/]?(\d*)/gi,
+    /(?:box\.?)\s?(\d*)[-|/]?(\d*)/gi,
     /^\d{1,3}$/gi
   ]
 
@@ -52,7 +53,6 @@ const extractVols = (matches) => {
     // [6,7,8] ==> [6,8]
     if (match.length > 2) match = [match[0], match[match.length - 1]]
     if (match.length === 1) match = [match[0], match[0]]
-
     return [...vols, match]
   }, [])
 }

--- a/lib/utils/volume-parse.js
+++ b/lib/utils/volume-parse.js
@@ -53,6 +53,8 @@ const extractVols = (matches) => {
     // [6,7,8] ==> [6,8]
     if (match.length > 2) match = [match[0], match[match.length - 1]]
     if (match.length === 1) match = [match[0], match[0]]
+    // we want to sort boxes in ascending order, and casting to a negative is
+    // moot because the sort are parses ranges on '-'.
     if (isABox) match = match.map((n) => 10000 - n)
     return [...vols, match]
   }, [])

--- a/test/unit/utils-volume-parse.test.js
+++ b/test/unit/utils-volume-parse.test.js
@@ -4,6 +4,9 @@ const { parseVolume } = require('../../lib/utils/volume-parse')
 
 describe('utils/volume-parse', () => {
   describe('parseVolume', () => {
+    it('returns negative values for boxes so archive sorts will be ascending', () => {
+      expect(parseVolume('Box 36')).to.deep.equal([[9964, 9964]])
+    })
     it('v. 36-37 (Nov. 1965-Oct. 1967)', () => {
       expect(parseVolume('v. 36-37 (Nov. 1965-Oct. 1967)')).to.deep.equal([[36, 37]])
     })


### PR DESCRIPTION
perhaps there is other work to be done to make this better... I'm parsing box numbers and then flipping them numerically to force an ascending sort. This really only helps when there are a majority of records with boxes. it does not make anything better or worse for a record like [this one](https://www.nypl.org/research/research-catalog/bib/b15059124). however, the heterogeneous nature of the metadata indicates to me that we should not be attempting to mechanically sort these, but rather finding a way to honor item sort from sierra.