### PR TITLE
Noref update browse term package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-kms": "^3.226.0",
         "@aws-sdk/client-sqs": "^3.835.0",
         "@elastic/elasticsearch": "~7.12.0",
-        "@nypl/browse-term": "^0.3.0",
+        "@nypl/browse-term": "^0.3.1",
         "@nypl/nypl-core-objects": "^2.1.1",
         "@nypl/nypl-data-api-client": "^2.0.0",
         "@nypl/nypl-streams-client": "^2.0.0",
@@ -7464,9 +7464,9 @@
       }
     },
     "node_modules/@nypl/browse-term": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nypl/browse-term/-/browse-term-0.3.0.tgz",
-      "integrity": "sha512-IJASIk6lH3tnUvZ1Ec4Xq7KW60uSPbpwebQ++4hOxe3JN6AH6S0gcKA7C4m6blAJrJJArMGIwaFSzWZe0SUK+A==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@nypl/browse-term/-/browse-term-0.3.1.tgz",
+      "integrity": "sha512-NyHccTn2XSR8bQVfmHahz2p1qAijcwdQCCTP7b3gPgCa7PeHymcGrUaDdOpZKBltxRGlUzwheSV5JLK+Lhxikw==",
       "dependencies": {
         "winston": "^3.17.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-kms": "^3.226.0",
     "@aws-sdk/client-sqs": "^3.835.0",
     "@elastic/elasticsearch": "~7.12.0",
-    "@nypl/browse-term": "^0.3.0",
+    "@nypl/browse-term": "^0.3.1",
     "@nypl/nypl-core-objects": "^2.1.1",
     "@nypl/nypl-data-api-client": "^2.0.0",
     "@nypl/nypl-streams-client": "^2.0.0",


### PR DESCRIPTION
to incorporate package changes for proper trimming, and removing $i and $4 from subject literal strings