### PR TITLE
Fix bug so that dates.raw will be a string

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -226,6 +226,7 @@ class EsBib extends EsBase {
   dates () {
     const dates = []
     const rawMarc = this.bib.varField('008')
+    if (!rawMarc || !rawMarc.length) { return [] }
     const type = this.bib.varFieldSegment('008', [6, 6])?.trim()
     const first = this.bib.varFieldSegment('008', [7, 10])?.trim()
     const second = this.bib.varFieldSegment('008', [11, 14])?.trim()
@@ -251,7 +252,7 @@ class EsBib extends EsBase {
           gte: `${first}-${month}-${day}`,
           lte: `${first}-${month}-${day}T23:59:59`
         },
-        raw: rawMarc,
+        raw: rawMarc[0].value,
         tag: type
       })
     }

--- a/lib/utils/es-ranges.js
+++ b/lib/utils/es-ranges.js
@@ -78,13 +78,14 @@ const roundDateUp = (date) => {
 const generateDateRangeFromYears = (first, second, rawMarc, type) => {
   const firstRoundedDown = roundDateDown(first)
   const secondRoundedUp = roundDateUp(second)
+  if (!rawMarc || !rawMarc.length) { return null }
   if (!firstRoundedDown) { return null }
   const date = {
     range: {
       gte: firstRoundedDown,
       lt: (parseInt(secondRoundedUp) + 1).toString()
     },
-    raw: rawMarc,
+    raw: rawMarc[0].value,
     tag: type
   }
   if (parseInt(date.range.lt) > 9999) {

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -141,11 +141,7 @@ describe('EsBib', function () {
             gte: '1977',
             lt: '2000'
           },
-          raw: [
-            {
-              value: '790530u197719uupl uu m||     0    |pol|ncas   '
-            }
-          ],
+          raw: '790530u197719uupl uu m||     0    |pol|ncas   ',
           tag: 'u'
         }
       ])
@@ -168,11 +164,7 @@ describe('EsBib', function () {
             gte: '1977',
             lt: '1978'
           },
-          raw: [
-            {
-              value: '790530m19771999pl uu m||     0    |pol|ncas   '
-            }
-          ],
+          raw: '790530m19771999pl uu m||     0    |pol|ncas   ',
           tag: 'm'
         },
         {
@@ -180,11 +172,7 @@ describe('EsBib', function () {
             gte: '1999',
             lt: '2000'
           },
-          raw: [
-            {
-              value: '790530m19771999pl uu m||     0    |pol|ncas   '
-            }
-          ],
+          raw: '790530m19771999pl uu m||     0    |pol|ncas   ',
           tag: 'm'
         }
       ])
@@ -207,11 +195,7 @@ describe('EsBib', function () {
             gte: '1977',
             lt: '1978'
           },
-          raw: [
-            {
-              value: '790530s1977uuuupl uu m||     0    |pol|ncas   '
-            }
-          ],
+          raw: '790530s1977uuuupl uu m||     0    |pol|ncas   ',
           tag: 's'
         }
       ])
@@ -234,11 +218,7 @@ describe('EsBib', function () {
             gte: '9999',
             lte: '9999'
           },
-          raw: [
-            {
-              value: '790530s9999uuuupl uu m||     0    |pol|ncas   '
-            }
-          ],
+          raw: '790530s9999uuuupl uu m||     0    |pol|ncas   ',
           tag: 's'
         }
       ])
@@ -261,11 +241,7 @@ describe('EsBib', function () {
             gte: '1977-06-05',
             lte: '1977-06-05T23:59:59'
           },
-          raw: [
-            {
-              value: '790530e19770605pl uu m||     0    |pol|ncas   '
-            }
-          ],
+          raw: '790530e19770605pl uu m||     0    |pol|ncas   ',
           tag: 'e'
         }
       ])
@@ -288,11 +264,7 @@ describe('EsBib', function () {
             gte: '1977',
             lt: '2000'
           },
-          raw: [
-            {
-              value: '790530u197719--5pl uu m||     0    |pol|ncas   '
-            }
-          ],
+          raw: '790530u197719--5pl uu m||     0    |pol|ncas   ',
           tag: 'u'
         }
       ])
@@ -315,11 +287,7 @@ describe('EsBib', function () {
             gte: '1900',
             lt: '2000'
           },
-          raw: [
-            {
-              value: '790530u19--19uupl uu m||     0    |pol|ncas   '
-            }
-          ],
+          raw: '790530u19--19uupl uu m||     0    |pol|ncas   ',
           tag: 'u'
         }
       ])


### PR DESCRIPTION
Fixes a big where the `dates.raw` field was being indexed as an object, whereas ES expects a string.
Also fixes tests.