### PR TITLE
Noref load nypl core in bulk

### DIFF
--- a/scripts/bulk-index.js
+++ b/scripts/bulk-index.js
@@ -124,6 +124,7 @@ const {
 } = require('./utils')
 const { setCredentials: kmsSetCredentials } = require('../lib/kms')
 const logger = require('../lib/logger')
+const { loadNyplCoreData } = require('../lib/load-core-data.js')
 logger.setLevel(process.env.LOG_LEVEL || 'info')
 
 if (process.env.NEW_RELIC_LICENSE_KEY && process.env.NEW_RELIC_APP_NAME) {
@@ -386,7 +387,7 @@ const buildSqlQuery = (options) => {
     ]
     options.limit = options.ids.length
 
-  // Support for a date range query
+    // Support for a date range query
   } else if (options.type && options.fromDate) {
     type = options.type
     const fromDate = options.fromDate
@@ -684,7 +685,7 @@ const run = async () => {
 }
 
 if (isCalledViaCommandLine) {
-  run()
+  loadNyplCoreData().then(() => run())
 }
 
 module.exports = {


### PR DESCRIPTION
NYPL core data has to be loaded asynchronously for any mappings to be used in the indexer. This PR adds a call to that loader method at the top of the bulk index script.