### PR TITLE
Add logic to handle detailed date type with fuzzy dates

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -19,6 +19,7 @@ const {
 const nyplCore = require('../load-core-data')
 const {
   generateDateRangeFromYears,
+  generateDateRangeFromSingleDate,
   InconsistentDateRange
 } = require('../utils/es-ranges')
 const logger = require('../logger')
@@ -293,14 +294,7 @@ class EsBib extends EsBase {
     if (type === 'e') {
       const month = second.slice(0, 2)
       const day = second.slice(2, 4)
-      dates.push({
-        range: {
-          gte: `${first}-${month}-${day}`,
-          lte: `${first}-${month}-${day}T23:59:59`
-        },
-        raw: rawMarc[0].value,
-        tag: type
-      })
+      dates.push(generateDateRangeFromSingleDate(year, month, day, rawMarc, type))
     }
     const filteredDates = dates.filter(x => x)
     return filteredDates

--- a/lib/utils/es-ranges.js
+++ b/lib/utils/es-ranges.js
@@ -100,6 +100,41 @@ const generateDateRangeFromYears = (first, second, rawMarc, type) => {
   return date
 }
 
+const generateDateRangeFromSingleDate = (year, month, day, rawMarc, type) => {
+    if (!year.match(/^\d{4}$/)) { return null }
+    if (!month.match(/^\d{2}$/)) {
+      return generateDateRangeFromYears(year, year, rawMarc, type)
+    }
+    if (day.match(/^\d{2}$/)) {
+      return {
+        range: {
+          gte: `${year}-${month}-${day}`,
+          lte: `${year}-${month}-${day}T23:59:59`
+        },
+        raw: rawMarc[0].value,
+        tag: type
+      }
+    }
+    if (parseInt(month) !== 12) {
+      return {
+        range: {
+          gte: `${year}-${month}-01`,
+          lt: `${year}-${parseInt(month) + 1}-01`
+        },
+        raw: rawMarc[0].value,
+        tag: type
+      }
+    }
+    return {
+      range: {
+        gte: `${year}-12-01`,
+        lt: `${year}-12-31T23:59:59`
+      },
+      raw: rawMarc[0].value,
+      tag: type
+    }
+}
+
 module.exports = {
   arrayToEsRangeObject,
   enumerationChronologySortFromEsRanges,
@@ -108,5 +143,6 @@ module.exports = {
   roundDateUp,
   roundDateDown,
   generateDateRangeFromYears,
+  generateDateRangeFromSingleDate,
   InconsistentDateRange
 }

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -281,6 +281,29 @@ describe('EsBib', function () {
         }
       ])
     })
+    it('handles detailed dates with incomplete date information', () => {
+      const record = new SierraBib(require('../fixtures/bib-10554371.json'))
+      record.varFields = record.varFields.filter(field => field.marcTag !== '008')
+      record.varFields.push({
+        fieldTag: 'y',
+        marcTag: '008',
+        ind1: ' ',
+        ind2: ' ',
+        content: '008    160906e201610  it a     b    001 0 ita dnam',
+        subfields: null
+      })
+      const esBib = new EsBib(record)
+      expect(esBib.dates()).to.deep.equal([
+        {
+          range: {
+            gte: '2016-10-01',
+            lt: '2016-11-01'
+          },
+          raw: '008    160906e201610  it a     b    001 0 ita dnam',
+          tag: 'e'
+        }
+      ])
+    })
     it('rounds fuzzy dates up', () => {
       const record = new SierraBib(require('../fixtures/bib-10554371.json'))
       record.varFields = record.varFields.filter(field => field.marcTag !== '008')


### PR DESCRIPTION
Fixes a bug we encountered with 008 fields like `'008 160906e201610 it a b 001 0 ita dnam'` which have a detailed date type but don't have a full day/month/year.

- Adds a new method to handle detailed dates that allows for some missing information, and ensures we don't write to the ES unless the output matches the expected format

- Adds a test 