### PR TITLE
Sync ES mappings and settings

### DIFF
--- a/lib/elastic-search/index-schema.js
+++ b/lib/elastic-search/index-schema.js
@@ -2,21 +2,19 @@ const propertyTemplates = {
   entity: {
     type: 'object',
     properties: {
-      id: { type: 'keyword', index: true },
-      label: { type: 'keyword', index: true }
+      id: { type: 'keyword' },
+      label: { type: 'keyword' }
     }
   },
   // This type should be used for "packed" fields containing ids & labels
   // munged together, which will only be matched exactly:
   packed: {
-    index: true,
     type: 'keyword',
     eager_global_ordinals: true
   },
   // This type should be used for text that we don't need analyzed for fuzzy
   // searching, but we do want to be able to filter on it using exact matching:
   exactString: {
-    index: true,
     type: 'keyword'
   },
   // This type should be used for text not worth analyzing for fuzzy-matching
@@ -26,23 +24,20 @@ const propertyTemplates = {
     type: 'keyword'
   },
   number: {
-    index: true,
     type: 'short'
   },
   // This type should be used for text properties that we want analyzed for
   // fuzzy searching, and we never expect to build an aggregation across it:
   fulltext: {
-    type: 'text',
-    index: true
+    type: 'text'
   },
   // Identical to above, but stores a secondary `folded` field with folding
   fulltextFolded: {
     type: 'text',
-    index: true,
     fields: {
       folded: {
         type: 'text',
-        analyzer: 'folding'
+        analyzer: 'folding_analyzer'
       }
     }
   },
@@ -51,7 +46,6 @@ const propertyTemplates = {
   // AND we anticipate accented chars we'd like folded:
   fulltextWithRawFolded: {
     type: 'text',
-    index: true,
     fields: {
       raw: {
         type: 'keyword',
@@ -59,13 +53,31 @@ const propertyTemplates = {
       },
       folded: {
         type: 'text',
-        analyzer: 'folding'
+        analyzer: 'folding_analyzer'
+      }
+    }
+  },
+  foldingStemmed: {
+    type: 'text',
+    fields: {
+      foldedStemmed: {
+        type: 'text',
+        analyzer: 'folding_stemming_analyzer'
+      }
+    }
+  },
+  identifier: {
+    type: 'keyword',
+    fields: {
+      clean: {
+        type: 'keyword',
+        ignore_above: 256,
+        normalizer: 'identifier_normalizer'
       }
     }
   },
   boolean: {
-    type: 'boolean',
-    index: true
+    type: 'boolean'
   }
 }
 
@@ -75,6 +87,11 @@ const compoundTemplates = {
       value: propertyTemplates.exactString,
       type: propertyTemplates.exactString,
       identifierStatus: propertyTemplates.exactString
+      /* identifierStatus: {
+        type: 'keyword',
+        normalizer: 'punctuation_and_lowercase_normalizer'
+      }
+      */
     }
   },
   electronicResources: {
@@ -89,13 +106,19 @@ const compoundTemplates = {
 // exists in dev & prod.
 exports.schema = () => ({
   addedAuthorTitle: propertyTemplates.fulltextFolded,
+  buildingLocationIds: {
+    type: 'keyword',
+    eager_global_ordinals: true
+  },
   carrierType: propertyTemplates.entity,
   carrierType_packed: propertyTemplates.packed,
-  collectionIds: propertyTemplates.exactString,
+  collectionIds: {
+    type: 'keyword',
+    eager_global_ordinals: true
+  },
   contentsTitle: propertyTemplates.fulltextFolded,
   contributorLiteral: {
     type: 'text',
-    index: true,
     fields: {
       raw: {
         type: 'keyword',
@@ -107,7 +130,7 @@ exports.schema = () => ({
       },
       folded: {
         type: 'text',
-        analyzer: 'folding'
+        analyzer: 'folding_analyzer'
       }
     }
   },
@@ -136,7 +159,6 @@ exports.schema = () => ({
   createdYear: propertyTemplates.number,
   creatorLiteral: {
     type: 'text',
-    index: true,
     fields: {
       raw: {
         type: 'keyword',
@@ -148,7 +170,7 @@ exports.schema = () => ({
       },
       folded: {
         type: 'text',
-        analyzer: 'folding'
+        analyzer: 'folding_analyzer'
       }
     }
   },
@@ -171,13 +193,28 @@ exports.schema = () => ({
     }
   },
   creator_sort: propertyTemplates.exactString,
+  dates: {
+    type: 'nested',
+    properties: {
+      range: {
+        type: 'date_range'
+      },
+      raw: {
+        type: 'keyword'
+      },
+      tag: {
+        type: 'keyword'
+      }
+    }
+  },
   dateStartYear: propertyTemplates.number,
-  description: propertyTemplates.fulltextFolded,
+  description: propertyTemplates.foldingStemmed,
   dimensions: propertyTemplates.exactString,
   donor: propertyTemplates.fulltextFolded,
   electronicResources: compoundTemplates.electronicResources,
   // TODO: there are things like extent and dimensions that dont seem like thiings we can or want to search on. should become exactStringNotIndexed
   extent: propertyTemplates.exactString,
+  formatId: propertyTemplates.exactString,
   formerTitle: propertyTemplates.fulltextFolded,
   genreForm: propertyTemplates.fulltextWithRawFolded,
   holdings: {
@@ -209,11 +246,14 @@ exports.schema = () => ({
       uri: propertyTemplates.exactString
     }
   },
-  idIsbn: propertyTemplates.exactString,
+  idIsbn: propertyTemplates.identifier,
   idIsbn_clean: propertyTemplates.exactString,
-  idIssn: propertyTemplates.exactString,
+  idIssn: propertyTemplates.identifier,
   idLcc: propertyTemplates.exactString,
-  idLccn: propertyTemplates.exactString,
+  idLccn: {
+    type: 'keyword',
+    normalizer: 'punctuation_and_lowercase_normalizer'
+  },
   idOclc: propertyTemplates.exactString,
   identifier: propertyTemplates.exactString,
   identifierV2: compoundTemplates.identifier,
@@ -268,8 +308,11 @@ exports.schema = () => ({
         // We're indexing this as text only so that it can be used in query_string
         // fulltext searches (if indexed keyword, can't by used fuzzily)
         type: 'text',
-        index: true,
         fields: {
+          keywordLowercased: {
+            type: 'keyword',
+            normalizer: 'shelfmark_normalizer'
+          },
           raw: {
             type: 'keyword'
           }
@@ -281,12 +324,10 @@ exports.schema = () => ({
       type: propertyTemplates.exactString,
       uri: propertyTemplates.exactString,
       volumeRange: {
-        type: 'integer_range',
-        index: true
+        type: 'integer_range'
       },
       volumeRaw: {
-        type: 'text',
-        index: true
+        type: 'text'
       }
     }
   },
@@ -299,7 +340,7 @@ exports.schema = () => ({
   mediaType_packed: propertyTemplates.packed,
   note: {
     properties: {
-      label: propertyTemplates.fulltextFolded,
+      label: propertyTemplates.foldingStemmed,
       noteType: propertyTemplates.exactString,
       // This only ever contains 'bf:Note':
       type: propertyTemplates.exactStringNotIndexed
@@ -321,14 +362,22 @@ exports.schema = () => ({
   parallelContributorLiteral: propertyTemplates.fulltextWithRawFolded,
   parallelDisplayField: {
     properties: {
-      fieldName: { type: 'keyword', index: true },
+      fieldName: { type: 'keyword' },
       index: propertyTemplates.number,
-      value: { type: 'text', index: true }
+      value: { type: 'text' }
     }
   },
   parallelPublisherLiteral: propertyTemplates.fulltextFolded,
   partOf: propertyTemplates.exactString,
-  placeOfPublication: propertyTemplates.exactString,
+  placeOfPublication: {
+    type: 'keyword',
+    fields: {
+      folded: {
+        type: 'text',
+        analyzer: 'folding_analyzer'
+      }
+    }
+  },
   popularity: propertyTemplates.number,
   publicDomain: propertyTemplates.boolean,
   publisherLiteral: propertyTemplates.fulltextWithRawFolded,
@@ -340,8 +389,11 @@ exports.schema = () => ({
     // We're indexing this as text only so that it can be used in query_string
     // fulltext searches (if indexed keyword, can't by used fuzzily)
     type: 'text',
-    index: true,
     fields: {
+      keywordLowercased: {
+        type: 'keyword',
+        normalizer: 'shelfmark_normalizer'
+      },
       raw: {
         type: 'keyword'
       }
@@ -358,7 +410,37 @@ exports.schema = () => ({
   },
   suppressed: propertyTemplates.boolean,
   tableOfContents: propertyTemplates.fulltextFolded,
-  title: propertyTemplates.fulltextFolded,
+  title: {
+    type: 'text',
+    fields: {
+      folded: {
+        type: 'text',
+        analyzer: 'folding_analyzer'
+      },
+      foldedStemmed: {
+        type: 'text',
+        analyzer: 'folding_stemming_analyzer'
+      },
+      keyword: {
+        type: 'keyword',
+        ignore_above: 256
+      },
+      keywordLowercased: {
+        type: 'keyword',
+        ignore_above: 256,
+        normalizer: 'lowercase_normalizer'
+      },
+      keywordLowercasedStripped: {
+        type: 'keyword',
+        ignore_above: 256,
+        normalizer: 'punctuation_and_lowercase_normalizer'
+      },
+      shingle: {
+        type: 'text',
+        analyzer: 'shingles_analyzer'
+      }
+    }
+  },
   title_sort: propertyTemplates.exactString,
   titleAlt: propertyTemplates.fulltextFolded,
   titleDisplay: propertyTemplates.fulltextFolded,

--- a/lib/elastic-search/index-settings.json
+++ b/lib/elastic-search/index-settings.json
@@ -1,0 +1,123 @@
+{
+  "number_of_shards": "2",
+  "max_inner_result_window": 3500,
+  "analysis": {
+    "filter": {
+      "icu_folding_filter": {
+        "type": "icu_folding"
+      },
+      "shingles_filter": {
+        "max_shingle_size": "3",
+        "min_shingle_size": "2",
+        "output_unigrams": "false",
+        "type": "shingle"
+      },
+      "en_stop_filter": {
+        "type": "stop",
+        "stopwords": "_english_"
+      },
+      "unique_stem": {
+        "type": "unique",
+        "only_on_same_position": "true"
+      },
+      "en_stem_filter": {
+        "name": "minimal_english",
+        "type": "stemmer"
+      }
+    },
+    "char_filter": {
+      "extended_punctuation_char_filter": {
+        "type": "mapping",
+        "mappings": [
+          "ʼ => '"
+        ]
+      },
+      "strip_punctuation": {
+        "pattern": "[\\p{Punct}]",
+        "type": "pattern_replace",
+        "replacement": ""
+      },
+      "clean_identifier_filter": {
+        "pattern": "[^0-9xX]",
+        "type": "pattern_replace",
+        "replacement": ""
+      },
+      "strip_shelfmark_punctuation": {
+        "pattern": "[!\"#$%&'(),-./:;<=>?\\[\\]^_`{|}~]",
+        "type": "pattern_replace",
+        "replacement": ""
+      }
+    },
+    "normalizer": {
+      "lowercase_normalizer": {
+        "filter": [
+          "asciifolding",
+          "lowercase"
+        ],
+        "type": "custom"
+      },
+      "punctuation_and_lowercase_normalizer": {
+        "filter": [
+          "asciifolding",
+          "lowercase"
+        ],
+        "type": "custom",
+        "char_filter": [
+          "strip_punctuation"
+        ]
+      },
+      "identifier_normalizer": {
+        "type": "custom",
+        "char_filter": [
+          "clean_identifier_filter"
+        ]
+      },
+      "shelfmark_normalizer": {
+        "filter": [
+          "asciifolding",
+          "lowercase"
+        ],
+        "type": "custom",
+        "char_filter": [
+          "strip_shelfmark_punctuation"
+        ]
+      }
+    },
+    "analyzer": {
+      "shingles_analyzer": {
+        "filter": [
+          "lowercase",
+          "asciifolding",
+          "shingles_filter"
+        ],
+        "type": "custom",
+        "tokenizer": "standard"
+      },
+      "folding_stemming_analyzer": {
+        "filter": [
+          "lowercase",
+          "icu_folding_filter",
+          "en_stop_filter",
+          "keyword_repeat",
+          "en_stem_filter",
+          "unique_stem"
+        ],
+        "char_filter": [
+          "extended_punctuation_char_filter",
+          "strip_punctuation"
+        ],
+        "tokenizer": "icu_tokenizer"
+      },
+      "folding_analyzer": {
+        "filter": [
+          "lowercase",
+          "icu_folding_filter"
+        ],
+        "char_filter": [
+          "extended_punctuation_char_filter"
+        ],
+        "tokenizer": "icu_tokenizer"
+      }
+    }
+  }
+}

--- a/scripts/initialize-index.js
+++ b/scripts/initialize-index.js
@@ -1,0 +1,62 @@
+/**
+* Script to initialize a new resources index. Includes creation, settings,
+* and mappings initialization.
+*
+* Usage:
+*   node scripts/initialize-index --envfile CONFIG --index INDEX
+*/
+const dotenv = require('dotenv')
+const fs = require('fs')
+const argv = require('minimist')(process.argv.slice(2))
+const logger = require('../lib/logger')
+const esClient = require('../lib/elastic-search/client')
+const { schema } = require('../lib/elastic-search/index-schema')
+const { awsCredentialsFromIni, die } = require('./utils')
+const { setCredentials: kmsSetCredentials } = require('../lib/kms')
+const indexSettings = require('../lib/elastic-search/index-settings.json')
+
+const usage = () => {
+  console.log('Usage: node mapping-check --envfile [path to .env] [--index INDEX]')
+  return true
+}
+
+// Ensure we're looking at the right profile
+const awsCreds = awsCredentialsFromIni()
+kmsSetCredentials(awsCreds)
+
+/**
+* Main script function.
+*/
+exports.run = async (options = {}) => {
+  const client = await esClient.client()
+  const exists = (await client.indices.exists({ index: options.index })).body
+
+  if (exists) {
+    die(`Index ${options.index} exists. Exiting`)
+  }
+
+  console.log(`Initializing ${options.index}`)
+
+  await client.indices.create({
+    index: options.index,
+    body: {
+      settings: indexSettings,
+      mappings: {
+        properties: schema()
+      }
+    }
+  })
+
+  console.log('Done')
+}
+
+const isCalledViaCommandLine = /scripts\/initialize-index(.js)?/.test(fs.realpathSync(process.argv[1]))
+if (isCalledViaCommandLine) {
+  if (!argv.envfile) usage() && die('--envfile required')
+  if (!argv.index) usage() && die('--index required')
+
+  dotenv.config({ path: argv.envfile })
+  logger.setLevel(process.env.LOG_LEVEL || 'info')
+
+  exports.run(argv)
+}


### PR DESCRIPTION
Updates the versioned index mappings to better match live mappings. The following prints a report of differences between live and configured mappings (and suggests `PUT` calls for pure additions):

`node scripts/mapping-check --envfile CONFIG`

Also adds current set of index settings to codebase and revives a basic tool for initializing a new index. This will enable to apply updated mappings to a new index by:

1. `node scripts/inittialize-index.js --envfile CONFIG --index resources-2025-09-...`
2. Start an overnight ES `_reindex` into the new index
3. In the morning, check for completion, activate new index in RCI & discovery-api, & rewind pollers.