### PR TITLE
Subject diffs and off by one fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,9 @@ const processRecords = async (type, records, options = {}) => {
   // and transmit to the browse pipeline. This must happen before writes to the
   // resources index to determine any diff between new and old subjects
   const changedRecords = [...filteredBibs, ...removedBibs]
+  let browseTermDiffs
   if ((changedRecords.length) && type === 'Bib') {
-    await browse.emitBibSubjectEvents(changedRecords)
+    browseTermDiffs = await browse.buildBibSubjectEvents(changedRecords)
   }
 
   if (recordsToIndex.length) {
@@ -80,7 +81,7 @@ const processRecords = async (type, records, options = {}) => {
 
     messages.push(`Deleted ${recordsToDelete.length} doc(s)`)
   }
-
+  await browse.emitBibSubjectEvents(browseTermDiffs)
   const message = messages.length ? messages.join('; ') : 'Nothing to do.'
 
   logger.info((options.dryrun ? 'DRYRUN: ' : '') + message)

--- a/lib/browse-terms/index.js
+++ b/lib/browse-terms/index.js
@@ -132,18 +132,16 @@ const fetchLiveSubjectLiterals = async (ids = []) => {
  * Sends extracted and fetched subject literal data for provided sierra bibs
 *  in batches of 10 (max value in SQS batch message) to the bib-browse-term SQS
  */
-const emitBibSubjectEvents = async (sierraBibs) => {
+const emitBibSubjectEvents = async (browseTerms) => {
   if (!process.env.ENCRYPTED_SQS_BROWSE_TERM_URL) return
-  const countEvents = await buildBibSubjectEvents(sierraBibs)
-  if (countEvents?.length === 0) {
+  if (browseTerms?.length === 0) {
     logger.debug('emitBibSubjectEvents: No bib subject events to emit.')
   }
   const sqsUrl = await kms.decrypt(process.env.ENCRYPTED_SQS_BROWSE_TERM_URL)
   try {
     const sqsClient = new SQSClient({})
-    const batchedCommands = buildBatchedCommands(countEvents, sqsUrl)
-    console.log(countEvents)
-    logger.info(`emitBibSubjectEvents: Writing ${countEvents.length} terms in ${batchedCommands.length} batches to SQS stream ${sqsUrl}`)
+    const batchedCommands = buildBatchedCommands(browseTerms, sqsUrl)
+    logger.info(`emitBibSubjectEvents: Writing ${browseTerms.length} terms in ${batchedCommands.length} batches to SQS stream ${sqsUrl}`)
     const responses = await Promise.allSettled(batchedCommands.map(async (command) => await sqsClient.send(command)))
     const success = responses.filter(({ status }) => status === 'fulfilled')
     const error = responses.filter(({ status }) => status === 'rejected')

--- a/lib/browse-terms/index.js
+++ b/lib/browse-terms/index.js
@@ -80,7 +80,7 @@ const determineUpdatedTerms = async (esResourcesProperty, idsToFetch, freshBibDa
   const liveTerms = await fetchPropertyForUris(idsToFetch, esResourcesProperty)
   const terms = await Promise.all(freshBibData.map(async (esBibDoc, idx) => {
     const freshTerms = await getSubjectModels(esBibDoc)
-    const liveTermsForBib = liveTerms.docs?.[idx]?._source?.[esResourcesProperty].map(term => ({ preferredTerm: term }))
+    const liveTermsForBib = liveTerms.docs?.[idx]?._source?.[esResourcesProperty]?.map(term => ({ preferredTerm: term }))
     const preferredTermPresentInBoth = (term) =>
       liveTermsForBib?.find((liveTerm) => liveTerm.preferredTerm === term.preferredTerm)
     const noUpdatedSubjects = freshTerms.every(preferredTermPresentInBoth)

--- a/lib/browse-terms/index.js
+++ b/lib/browse-terms/index.js
@@ -142,6 +142,7 @@ const emitBibSubjectEvents = async (sierraBibs) => {
   try {
     const sqsClient = new SQSClient({})
     const batchedCommands = buildBatchedCommands(countEvents, sqsUrl)
+    console.log(countEvents)
     logger.info(`emitBibSubjectEvents: Writing ${countEvents.length} terms in ${batchedCommands.length} batches to SQS stream ${sqsUrl}`)
     const responses = await Promise.allSettled(batchedCommands.map(async (command) => await sqsClient.send(command)))
     const success = responses.filter(({ status }) => status === 'fulfilled')

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -53,11 +53,12 @@ describe('index handler function', () => {
     modelPrefetchStub.resetHistory()
   })
   describe('processRecords', () => {
-    it('calls deletions after subject processing has happened', async () => {
+    it('calls deletions after subject diff is determined', async () => {
       const suppressBibsStub = stub(suppress, 'suppressBibs')
-      const emitBibSubjectEventsStub = stub(browse, 'emitBibSubjectEvents')
+      stub(browse, 'emitBibSubjectEvents')
+      const buildBibSubjectEventsStub = stub(browse, 'buildBibSubjectEvents')
       await index.processRecords('Bib', [suppressedBib])
-      expect(emitBibSubjectEventsStub.calledBefore(suppressBibsStub)).to.equal(true)
+      expect(buildBibSubjectEventsStub.calledBefore(suppressBibsStub)).to.equal(true)
     })
   })
 


### PR DESCRIPTION
This PR includes:
- creating diff of new subjects generated and existing subjects in resources index, instead of sending all new and live subjects
- conditionally skipping this check if optional flag for ingest is true, in which case we want to just send only the new subjects
- a fix for a bug introduced from the above changes:
   - generate the subject events before writes/deletes to the resources index, 
   - send them to the sqs stream after writes/deletes to the resources index.

I tested the bugfix by:
1. reindexing 20 bibs with the existing code (building diff and sending subject events before resources updates), adding an additional " spaghetti"  to every subject. (addition was to ensure that subjects and counts would be brand new)
  - On some, I was getting zero counts in the BTI logs. This could indicate that counts are generated before resources bib updates were completed
2. I reset them all back to their original state (rm spaghetti)
3. ran the same process again with my proposed fix, adding spaghetti again
  - saw no zero counts in the bti logs, hopefully indicating that the counts were fetched after writes to the resources index allowed for accurate counts on updated bibs