### PR TITLE
Make date type 'm' a range + small fixes

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -272,7 +272,7 @@ class EsBib extends EsBase {
     try {
       // these types indicate date ranges. The 008 field is interpreted as a
       // single range defined by two YYYY dates
-      if (['c', 'd', 'i', 'k', 'u'].includes(type)) {
+      if (['c', 'd', 'i', 'k', 'm', 'u'].includes(type)) {
         try {
           dates.push(generateDateRangeFromYears(first, second, rawMarc, type))
         } catch (e) {
@@ -286,7 +286,7 @@ class EsBib extends EsBase {
       }
       // these types indicate multiple dates. The 008 field is interpreted as two
       // separate YYYY dates, each of which is indexed as a 1-year range
-      if (['m', 'p', 'q', 'r', 's', 't'].includes(type)) {
+      if (['p', 'q', 'r', 's', 't'].includes(type)) {
         dates.push(generateDateRangeFromYears(first, first, rawMarc, type))
         dates.push(generateDateRangeFromYears(second, second, rawMarc, type))
       }

--- a/lib/utils/es-ranges.js
+++ b/lib/utils/es-ranges.js
@@ -58,12 +58,15 @@ const enumerationChronologySortFromEsRanges = (volumeRange, dateRange) => {
   return enumerationChronologySort
 }
 
+class InconsistentDateRange extends Error {}
+
+class InvalidDateError extends Error {}
 // accepts a string representing a year, possibly with some digits unspecified,
 // but expects at least the first digit
 // returns the earliest date consistent with that partially specified year
 // used to populate the beginning of date ranges for bibs
 const roundDateDown = (date) => {
-  if (!date.match(/^\d/g)) { return null }
+  if (!date.match(/^\d/g)) { throw new InvalidDateError() }
   return date.replaceAll(/[^\d]/g, 0)
 }
 
@@ -72,12 +75,9 @@ const roundDateDown = (date) => {
 // returns the latest date consistent with that partially specified year
 // used to populate the end of date ranges for bibs
 const roundDateUp = (date) => {
-  if (!date.match(/^\d{0,}[^\d]{0,4}$/)) { return null }
+  if (!date.match(/^\d{0,}[^\d]{0,4}$/)) { throw new InvalidDateError() }
   return date.replaceAll(/[^\d]/g, 9)
 }
-
-class InconsistentDateRange extends Error {}
-class InvalidDateError extends Error {}
 
 const validateDate = (dateObj) => {
   const validatedDate = dateObj

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -181,7 +181,7 @@ describe('EsBib', function () {
         }
       ])
     })
-    it('creates a multiple dates', () => {
+    it('creates a range of dates for type m', () => {
       const record = new SierraBib(require('../fixtures/bib-10554371.json'))
       record.varFields = record.varFields.filter(field => field.marcTag !== '008')
       record.varFields.push({
@@ -189,7 +189,30 @@ describe('EsBib', function () {
         marcTag: '008',
         ind1: ' ',
         ind2: ' ',
-        content: '790530m19771999pl uu m||     0    |pol|ncas   ',
+        content: '790530m197719uupl uu m||     0    |pol|ncas   ',
+        subfields: null
+      })
+      const esBib = new EsBib(record)
+      expect(esBib.dates()).to.deep.equal([
+        {
+          range: {
+            gte: '1977',
+            lt: '2000'
+          },
+          raw: '790530m197719uupl uu m||     0    |pol|ncas   ',
+          tag: 'm'
+        }
+      ])
+    })
+    it('creates multiple dates', () => {
+      const record = new SierraBib(require('../fixtures/bib-10554371.json'))
+      record.varFields = record.varFields.filter(field => field.marcTag !== '008')
+      record.varFields.push({
+        fieldTag: 'y',
+        marcTag: '008',
+        ind1: ' ',
+        ind2: ' ',
+        content: '790530r19771999pl uu m||     0    |pol|ncas   ',
         subfields: null
       })
       const esBib = new EsBib(record)
@@ -199,16 +222,16 @@ describe('EsBib', function () {
             gte: '1977',
             lt: '1978'
           },
-          raw: '790530m19771999pl uu m||     0    |pol|ncas   ',
-          tag: 'm'
+          raw: '790530r19771999pl uu m||     0    |pol|ncas   ',
+          tag: 'r'
         },
         {
           range: {
             gte: '1999',
             lt: '2000'
           },
-          raw: '790530m19771999pl uu m||     0    |pol|ncas   ',
-          tag: 'm'
+          raw: '790530r19771999pl uu m||     0    |pol|ncas   ',
+          tag: 'r'
         }
       ])
     })
@@ -257,6 +280,20 @@ describe('EsBib', function () {
           tag: 's'
         }
       ])
+    })
+    it('rejects invalid dates', () => {
+      const record = new SierraBib(require('../fixtures/bib-10554371.json'))
+      record.varFields = record.varFields.filter(field => field.marcTag !== '008')
+      record.varFields.push({
+        fieldTag: 'y',
+        marcTag: '008',
+        ind1: ' ',
+        ind2: ' ',
+        content: '970604d195019u8ja uu        f0   d0jpn  ',
+        subfields: null
+      })
+      const esBib = new EsBib(record)
+      expect(esBib.dates()).to.deep.equal([])
     })
     it('creates detailed dates', () => {
       const record = new SierraBib(require('../fixtures/bib-10554371.json'))


### PR DESCRIPTION
Some changes that came out of discussions following our initial QA indexing of partner records:

- Make date type 'm' a date range
- Add throwing error for invalid dates (currently we are returning `null` which causes an uncaught error in a small number of cases. Purposely throwing an `InvalidDateError` when dates fail validation is more semantically correct and allows us to catch the error in the parent block)
- Fix/add tests