### PR TITLE
Add separate logic for type s

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -284,9 +284,14 @@ class EsBib extends EsBase {
           }
         }
       }
+      // this type represents a single date, represented as YYYY in the first four
+      // characters:
+      if (type === 's') {
+        dates.push(generateDateRangeFromYears(first, first, rawMarc, type))
+      }
       // these types indicate multiple dates. The 008 field is interpreted as two
       // separate YYYY dates, each of which is indexed as a 1-year range
-      if (['p', 'q', 'r', 's', 't'].includes(type)) {
+      if (['p', 'q', 'r', 't'].includes(type)) {
         dates.push(generateDateRangeFromYears(first, first, rawMarc, type))
         dates.push(generateDateRangeFromYears(second, second, rawMarc, type))
       }


### PR DESCRIPTION
Fixes an issue where dates of type `s` generate a lot of extraneous noisy logs
- A previous fix added some log warnings for all dates that don't validate
- The existing code groups type `s`, which always has a blank for the second date, with the multiple-date types
- This generates a warning for all dates of type `s` because the blank isn't a valid date

The solution is to separate `s` into its own block that only expects to index a single date