### PR TITLE
Noref/skip blank dates

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -273,16 +273,7 @@ class EsBib extends EsBase {
       // these types indicate date ranges. The 008 field is interpreted as a
       // single range defined by two YYYY dates
       if (['c', 'd', 'i', 'k', 'm', 'u'].includes(type)) {
-        try {
-          dates.push(generateDateRangeFromYears(first, second, rawMarc, type))
-        } catch (e) {
-          if (e instanceof InconsistentDateRange) {
-            logger.warn(`Inconsistent date range. Date warning for: ${this.bib.id}. Marc: ${rawMarc[0].value}`)
-          } else {
-            logger.error(`Unexpected error in dates ${this.bib.id}`)
-            throw e
-          }
-        }
+        dates.push(generateDateRangeFromYears(first, second, rawMarc, type))
       }
       // these types indicate multiple dates. The 008 field is interpreted as two
       // separate YYYY dates, each of which is indexed as a 1-year range
@@ -306,7 +297,7 @@ class EsBib extends EsBase {
       } else if (e instanceof InconsistentDateRange) {
         logger.warn(`Inconsistent date range. Date warning for: ${this.bib.id}. Marc: ${rawMarc[0].value}`)
       } else {
-        logger.error(`Unexpected error in dates ${this.bib.id}`)
+        logger.error(`Unexpected error in dates ${this.bib.id}. Marc: ${rawMarc[0].value}`)
         throw e
       }
     }

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -284,9 +284,14 @@ class EsBib extends EsBase {
           }
         }
       }
+      // this type represents a single date, represented as YYYY in the first four
+      // characters:
+      if (type === 's') {
+        dates.push(generateDateRangeFromYears(first, first, rawMarc, type))
+      }
       // these types indicate multiple dates. The 008 field is interpreted as two
       // separate YYYY dates, each of which is indexed as a 1-year range
-      if (['p', 'q', 'r', 's', 't'].includes(type)) {
+      if (['p', 'q', 'r', 't'].includes(type)) {
         dates.push(generateDateRangeFromYears(first, first, rawMarc, type))
         dates.push(generateDateRangeFromYears(second, second, rawMarc, type))
       }

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -284,16 +284,13 @@ class EsBib extends EsBase {
           }
         }
       }
-      // this type represents a single date, represented as YYYY in the first four
-      // characters:
-      if (type === 's') {
-        dates.push(generateDateRangeFromYears(first, first, rawMarc, type))
-      }
       // these types indicate multiple dates. The 008 field is interpreted as two
       // separate YYYY dates, each of which is indexed as a 1-year range
-      if (['p', 'q', 'r', 't'].includes(type)) {
+      if (['p', 'q', 'r', 's', 't'].includes(type)) {
         dates.push(generateDateRangeFromYears(first, first, rawMarc, type))
-        dates.push(generateDateRangeFromYears(second, second, rawMarc, type))
+        if (!second.match(/^[u\s]{4}$/)) {
+          dates.push(generateDateRangeFromYears(second, second, rawMarc, type))
+        }
       }
       // type e is a special case where the first field is a YYYY year and the
       // second field is a day in MMDD format. We index it as a single

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -288,7 +288,7 @@ class EsBib extends EsBase {
       // separate YYYY dates, each of which is indexed as a 1-year range
       if (['p', 'q', 'r', 's', 't'].includes(type)) {
         dates.push(generateDateRangeFromYears(first, first, rawMarc, type))
-        if (!second.match(/^[u\s]{4}$/)) {
+        if (!second.match(/^[u\s|]{4}$/)) {
           dates.push(generateDateRangeFromYears(second, second, rawMarc, type))
         }
       }


### PR DESCRIPTION
A previous PR added some extra warning for invalid dates. This resulted in a lot of noisy extraneous warnings for multiple-date types when the second date is blank. This PR fixes this by skipping the second date if it is blank