### PR TITLE
Add (wip) rewind-indexer script

### DIFF
--- a/scripts/rewind-indexer.sh
+++ b/scripts/rewind-indexer.sh
@@ -1,0 +1,28 @@
+# This script sets the primary Kinesis triggers for RCI to a specific timestamp.
+# Useful when we've created a new index, switched RCI over to use it, and now
+# need to tell it to re-process from some point in the past (usually the point
+# in time immediately preceding when we started to create the new index)
+
+# Usage:
+#  - First delete the old triggers manually
+#  - Set FROM_TIMESTAMP below to a timestamp that precedes the start of your `_reindex`
+#  - Set ENV appropriately
+#  - Run ./scripts/rewind-indexer.sh
+
+FROM_TIMESTAMP=2026-02-12T12:00:00-05:00
+ENV=production
+
+echo Setting triggers for ResearchCatalogIndexer-$ENV to $FROM_TIMESTAMP
+
+for STREAM in Bib Item Holding; do
+  echo Setting $STREAM-$ENV trigger..
+
+  aws lambda create-event-source-mapping \
+    --function-name ResearchCatalogIndexer-$ENV \
+    --event-source-arn arn:aws:kinesis:us-east-1:946183545209:stream/$STREAM-$ENV \
+    --batch-size 50 \
+    --starting-position AT_TIMESTAMP \
+    --starting-position-timestamp $FROM_TIMESTAMP \
+    --bisect-batch-on-function-error \
+    --profile nypl-digital-dev
+done

--- a/scripts/rewind-indexer.sh
+++ b/scripts/rewind-indexer.sh
@@ -4,12 +4,12 @@
 # in time immediately preceding when we started to create the new index)
 
 # Usage:
-#  - First delete the old triggers manually
-#  - Set FROM_TIMESTAMP below to a timestamp that precedes the start of your `_reindex`
+#  - First delete the old Bib, Item, and Holding triggers manually
+#  - Set FROM_TIMESTAMP (below) to a value that precedes the start of your `_reindex`
 #  - Set ENV appropriately
 #  - Run ./scripts/rewind-indexer.sh
 
-FROM_TIMESTAMP=2026-02-12T12:00:00-05:00
+FROM_TIMESTAMP=2026-02-12T15:10:00-05:00
 ENV=production
 
 echo Setting triggers for ResearchCatalogIndexer-$ENV to $FROM_TIMESTAMP

--- a/scripts/rewind-indexer.sh
+++ b/scripts/rewind-indexer.sh
@@ -4,13 +4,14 @@
 # in time immediately preceding when we started to create the new index)
 
 # Usage:
-#  - First delete the old Bib, Item, and Holding triggers manually
-#  - Set FROM_TIMESTAMP (below) to a value that precedes the start of your `_reindex`
-#  - Set ENV appropriately
-#  - Run ./scripts/rewind-indexer.sh
+#  - First, manually delete the old Bib, Item, and Holding triggers in the console
+#  - Run:
+#     ./scripts/rewind-indexer.sh (qa|production) [TIMESTAMP]
+#  - e.g.:
+#     ./scripts/rewind-indexer.sh production 2026-05-26T14:00:00-05:00
 
-FROM_TIMESTAMP=2026-02-12T15:10:00-05:00
-ENV=production
+ENV=$1
+FROM_TIMESTAMP=$2
 
 echo Setting triggers for ResearchCatalogIndexer-$ENV to $FROM_TIMESTAMP
 


### PR DESCRIPTION
Adds simple script for updating the triggers in either environment to reprocess events from a specified time. Helpful for ensuring we pick up all updates that we might have missed while building a new index.