### PR TITLE
Update bib sort fields to strip leading articles

### DIFF
--- a/lib/elastic-search/index-schema.js
+++ b/lib/elastic-search/index-schema.js
@@ -17,6 +17,12 @@ const propertyTemplates = {
   exactString: {
     type: 'keyword'
   },
+  // Used in sorting- this will strip out leading articles ("the", "a", and "an")
+  // and use lowercase + folding.
+  sortString: {
+    type: 'keyword',
+    normalizer: 'sort_normalizer'
+  },
   // This type should be used for text not worth analyzing for fuzzy-matching
   // and we don't expect to ever use it in an exact-match query either:
   exactStringNotIndexed: {
@@ -171,7 +177,7 @@ exports.schema = () => ({
       }
     }
   },
-  contributor_sort: propertyTemplates.exactString,
+  contributor_sort: propertyTemplates.sortString,
   createdString: propertyTemplates.exactString,
   createdYear: propertyTemplates.number,
   // contains names (matching browse index) packed with full creator label (name, prefix, title, roles)
@@ -211,7 +217,7 @@ exports.schema = () => ({
       }
     }
   },
-  creator_sort: propertyTemplates.exactString,
+  creator_sort: propertyTemplates.sortString,
   dates: {
     type: 'nested',
     properties: {
@@ -465,7 +471,7 @@ exports.schema = () => ({
       }
     }
   },
-  title_sort: propertyTemplates.exactString,
+  title_sort: propertyTemplates.sortString,
   titleAlt: propertyTemplates.fulltextWithRawFolded,
   titleDisplay: propertyTemplates.fulltextFolded,
   type: propertyTemplates.exactString,

--- a/lib/elastic-search/index-settings.json
+++ b/lib/elastic-search/index-settings.json
@@ -46,6 +46,11 @@
         "pattern": "[!\"#$%&'(),-./:;<=>?\\[\\]^_`{|}~]",
         "type": "pattern_replace",
         "replacement": ""
+      },
+      "strip_leading_articles": {
+          "type": "pattern_replace",
+          "pattern": "^(?i)(?:a|an|the)\\s+",
+          "replacement": ""
       }
     },
     "normalizer": {
@@ -80,6 +85,16 @@
         "type": "custom",
         "char_filter": [
           "strip_shelfmark_punctuation"
+        ]
+      },
+      "sort_normalizer": {
+        "filter": [
+          "asciifolding",
+          "lowercase"
+        ],
+        "type": "custom",
+        "char_filter": [
+          "strip_leading_articles"
         ]
       }
     },


### PR DESCRIPTION
* Ticket: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4597
* This updates title and contributor sorts to strip out leading articles ("a", "an" and "the") for sorting purposes.
* Note that I haven't actually updated the index settings / mappings for this- I think we'll need to make a new index and reindex into it to change the normalizer on these fields and I would like to get eyes on the proposed change before doing so.