### PR TITLE
Excludes series added authors from contributor display

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -186,7 +186,7 @@ class EsBib extends EsBase {
   }
 
   contributors_displayPacked () {
-    const contributors = this.browseTermData.contributor.filter(Boolean)
+    const contributors = this.browseTermData.contributorLiteral.filter(Boolean)
 
     if (!contributors) return null
 
@@ -1304,7 +1304,7 @@ class EsBib extends EsBase {
 
   _populateBrowseTermData () {
     this.browseTermData = {}
-    this.browseTermData.contributor = this._buildBrowseableTermData(ContributorVarfield, 'contributor')
+    this.browseTermData.contributor = this._buildBrowseableTermData(ContributorVarfield, 'allContributors')
     this.browseTermData.contributorLiteral = this._buildBrowseableTermData(ContributorVarfield, 'contributorLiteral')
     this.browseTermData.creatorLiteral = this._buildBrowseableTermData(ContributorVarfield, 'creatorLiteral')
     this.browseTermData.subject = this._buildBrowseableTermData(SubjectVarfield, 'subjectLiteral')

--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -184,7 +184,7 @@
 
     ]
   },
-  "contributor": {
+  "allContributors": {
     "paths": [
       {"marc": "100"},
       {"marc": "110"},


### PR DESCRIPTION
* This was causing some duplication between the Series Added Entry field and the Additional Authors field when doing `_displayPacked`. We don't need both! See [here](https://research-catalog-git-scc-5195-bib-details-series-nypl.vercel.app/research/research-catalog/bib/b10584709) for an example of the duplication
* Also small name change to clear up confusion in the bib mapping file: `contributor` -> `allContributors`