### PR TITLE
Series ♾️

### DIFF
--- a/lib/es-models/base.js
+++ b/lib/es-models/base.js
@@ -68,18 +68,18 @@ class EsBase {
     return plainObject
   }
 
-  _parallelValueToIndexFromBasicMapping (field) {
-    return this._valueToIndexFromBasicMapping(field, false)
+  _parallelValueToIndexFromBasicMapping (field, dedupe = true) {
+    return this._valueToIndexFromBasicMapping(field, false, dedupe)
   }
 
-  _valueToIndexFromBasicMapping (field, primary = true) {
-    const fields = this._varFieldMatchesForBasicMapping(field)
+  _valueToIndexFromBasicMapping (field, primary = true, dedupe = true) {
+    const fields = this._varFieldMatchesForBasicMapping(field, dedupe)
     const values = primary ? primaryValues(fields) : parallelValues(fields)
     const normalizedValues = values.map(value => combineLigaturePairs(value))
     return normalizedValues.length === 0 ? null : normalizedValues
   }
 
-  _varFieldMatchesForBasicMapping (field) {
+  _varFieldMatchesForBasicMapping (field, dedupe = true) {
     // due to implcit binding, `this` refers to the object where this method is called, which is an Elastic Search model (bib, item, or holding)
     const esRecordType = this.constructor.name
     let mapping
@@ -97,7 +97,7 @@ class EsBase {
       record = 'bib'
     }
     const mappings = mapping.get(field, this[record])
-    return this[record].varFieldsMulti(mappings)
+    return this[record].varFieldsMulti(mappings, false, dedupe)
   }
 }
 

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -710,9 +710,9 @@ class EsBib extends EsBase {
   }
 
   parallelSeriesAddedEntry () {
-    return this.browseTermData.seriesAddedEntry
-      .map(term => term?.variant)
-      .filter(Boolean)
+    const values = this._parallelValueToIndexFromBasicMapping('seriesAddedEntry')
+    // remove empty strings introduced by primaries without parallel content
+    return values ? values.filter(Boolean) : null
   }
 
   parallelSubjectLiteral () {
@@ -829,49 +829,58 @@ class EsBib extends EsBase {
   }
 
   seriesAddedEntry () {
-    const series = this.browseTermData.seriesAddedEntry.filter(Boolean)
-    if (!series.length) return null
-    return series.map(term => term.label || term.name)
+    return this._valueToIndexFromBasicMapping('seriesAddedEntry')
   }
 
   series_displayPacked () {
     const displayPacked = this._valueToIndexFromBasicMapping('series_displayPacked')
-    if (!this.series() || !displayPacked) return null
-    return [`${this.series()}||${displayPacked}`]
+    // Get series without deduping
+    const series = this._valueToIndexFromBasicMapping('series', true, false)
+    if (!series || !displayPacked) return null
+    return series.map((s, i) => `${s}||${displayPacked[i]}`)
   }
 
   seriesUniformTitle_displayPacked () {
     const displayPacked = this._valueToIndexFromBasicMapping('seriesUniformTitle_displayPacked')
-    if (!this.seriesUniformTitle() || !displayPacked) return null
-    return [`${this.seriesUniformTitle()}||${displayPacked}`]
+    // Get seriesUniformTitle without deduping
+    const seriesUniformTitle = this._valueToIndexFromBasicMapping('seriesUniformTitle', true, false)
+    if (!seriesUniformTitle || !displayPacked) return null
+    return seriesUniformTitle.map((s, i) => `${s}||${displayPacked[i]}`)
   }
 
   seriesAddedEntry_displayPacked () {
-    const series = this.browseTermData.seriesAddedEntry.filter(Boolean)
-    if (!series.length) return null
-
-    return series.map(term =>
-      term.name + '||' + term.label
-    )
+    const displayPacked = this._valueToIndexFromBasicMapping('seriesAddedEntry_displayPacked')
+    // Get seriesAddedEntry without deduping
+    const seriesAddedEntry = this._valueToIndexFromBasicMapping('seriesAddedEntry', true, false)
+    if (!seriesAddedEntry || !displayPacked) return null
+    return seriesAddedEntry.map((s, i) => `${s}||${displayPacked[i]}`)
   }
 
   parallelSeries_displayPacked () {
     const displayPacked = this._parallelValueToIndexFromBasicMapping('series_displayPacked')
-    if (!this.parallelSeries() || !displayPacked) return null
-    return [`${this.parallelSeries()}||${displayPacked}`]
+    // Get parallel series without deduping
+    const parallelSeries = this._parallelValueToIndexFromBasicMapping('series', false)
+    if (!parallelSeries || !displayPacked) return null
+    const packed = parallelSeries.map((s, i) => (s && displayPacked[i]) ? `${s}||${displayPacked[i]}` : null).filter(Boolean)
+    return packed.length ? packed : null
   }
 
   parallelSeriesUniformTitle_displayPacked () {
     const displayPacked = this._parallelValueToIndexFromBasicMapping('seriesUniformTitle_displayPacked')
-    if (!this.parallelSeriesUniformTitle() || !displayPacked) return null
-    return [`${this.parallelSeriesUniformTitle()}||${displayPacked}`]
+    // Get parallel seriesUniformTitle without deduping
+    const parallelSeriesUniformTitle = this._parallelValueToIndexFromBasicMapping('seriesUniformTitle', false)
+    if (!parallelSeriesUniformTitle || !displayPacked) return null
+    const packed = parallelSeriesUniformTitle.map((s, i) => (s && displayPacked[i]) ? `${s}||${displayPacked[i]}` : null).filter(Boolean)
+    return packed.length ? packed : null
   }
 
   parallelSeriesAddedEntry_displayPacked () {
-    return this.browseTermData.seriesAddedEntry.map(term => {
-      if (!term || !term.variant) return null
-      return term.variant + '||' + term.variantLabel
-    }).filter(Boolean)
+    const displayPacked = this._parallelValueToIndexFromBasicMapping('seriesAddedEntry_displayPacked')
+    // Get parallel seriesAddedEntry without deduping
+    const parallelSeriesAddedEntry = this._parallelValueToIndexFromBasicMapping('seriesAddedEntry', false)
+    if (!parallelSeriesAddedEntry || !displayPacked) return null
+    const packed = parallelSeriesAddedEntry.map((s, i) => (s && displayPacked[i]) ? `${s}||${displayPacked[i]}` : null).filter(Boolean)
+    return packed.length ? packed : null
   }
 
   shelfMark () {
@@ -1308,8 +1317,6 @@ class EsBib extends EsBase {
     this.browseTermData.contributorLiteral = this._buildBrowseableTermData(ContributorVarfield, 'contributorLiteral')
     this.browseTermData.creatorLiteral = this._buildBrowseableTermData(ContributorVarfield, 'creatorLiteral')
     this.browseTermData.subject = this._buildBrowseableTermData(SubjectVarfield, 'subjectLiteral')
-    this.browseTermData.seriesAddedEntry =
-  this._buildBrowseableTermData(ContributorVarfield, 'seriesAddedEntry')
   }
 
   /**

--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -1003,7 +1003,7 @@
       {
         "marc": "830",
         "excludedSubfields": [
-          "v", "6"
+          "v", "6", "0"
         ],
         "subfieldJoiner": " "
       }
@@ -1014,7 +1014,7 @@
       {
         "marc": "830",
         "excludedSubfields": [
-          "6"
+          "6", "0"
         ],
         "subfieldJoiner": " "
       }
@@ -1023,13 +1023,50 @@
   "seriesAddedEntry": {
     "paths": [
       {
-        "marc": "800"
+        "marc": "800",
+        "excludedSubfields": [
+          "v", "6", "0"
+        ],
+        "subfieldJoiner": " "
       },
       {
-        "marc": "810"
+        "marc": "810",
+        "excludedSubfields": [
+          "v", "6", "0"
+        ],
+        "subfieldJoiner": " "
       },
       {
-        "marc": "811"
+        "marc": "811",
+        "excludedSubfields": [
+          "v", "6", "0"
+        ],
+        "subfieldJoiner": " "
+      }
+    ]
+  },
+  "seriesAddedEntry_displayPacked": {
+    "paths": [
+      {
+        "marc": "800",
+        "excludedSubfields": [
+          "6", "0"
+        ],
+        "subfieldJoiner": " "
+      },
+      {
+        "marc": "810",
+        "excludedSubfields": [
+          "6", "0"
+        ],
+        "subfieldJoiner": " "
+      },
+      {
+        "marc": "811",
+        "excludedSubfields": [
+          "6", "0"
+        ],
+        "subfieldJoiner": " "
       }
     ]
   },

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -257,7 +257,7 @@ class SierraBase {
    *
    * @return {VarFieldMatch[]}
    */
-  varFieldsMulti (marcObjects, includeMarc = false) {
+  varFieldsMulti (marcObjects, includeMarc = false, dedupe = true) {
     let matches = marcObjects
       .map(({ marc, subfields, mappingOptions }) => {
         const options = Object.assign({}, mappingOptions, { dedupe: false, includeMarc })
@@ -278,7 +278,7 @@ class SierraBase {
         return a.varFieldIndex > b.varFieldIndex ? 1 : -1
       })
     // De-dupe based on primary and parallel values:
-    matches = this._uniqueVarFieldMatches(matches)
+    if (dedupe) { matches = this._uniqueVarFieldMatches(matches) }
 
     return matches
   }

--- a/test/fixtures/bib-series.json
+++ b/test/fixtures/bib-series.json
@@ -18,6 +18,16 @@
         ]
       },
       {
+        "marcTag": "490",
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+          {"tag": "6", "content": "880-01"},
+          {"tag": "a", "content": "490 Series: The Psychology of C.G. Jung"},
+          {"tag": "v", "content": "v. 2"}
+        ]
+      },
+      {
         "marcTag": "800",
         "ind1": "1",
         "ind2": " ",
@@ -35,6 +45,7 @@
         "ind1": "1",
         "ind2": " ",
         "subfields": [
+          {"tag": "0", "content": "810 $0 this shouldn't display"},
           {"tag": "a", "content": "810 Series Added Entry: United States"},
           {"tag": "b", "content": "Congress"},
           {"tag": "b", "content": "House"},

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -2105,12 +2105,12 @@ describe('EsBib', function () {
         '830 Series Uniform Title parallel: 心理学系列'
       ])
     })
-    it('extracts seriesAddedEntry (800, 810, 811 fields, excluding $6)', async () => {
+    it('extracts seriesAddedEntry (800, 810, 811 fields, excluding $v and 0)', async () => {
       const result = await esBib.seriesAddedEntry()
       expect(result).to.deep.equal([
-        '800 Series Added Entry: Meier, C. A. (Carl Alfred) 1905-1995 Lehrbuch der komplexen Psychologie C.G. Jungs English v. 1',
-        '810 Series Added Entry: United States Congress House Report 112-664',
-        '811 Series Added Entry: Inter-American Conference on Agriculture (3rd : 1945 : Caracas, Venezuela) Cuadernos verdes Serie nacional 14'
+        '800 Series Added Entry: Meier, C. A. (Carl Alfred) 1905-1995 Lehrbuch der komplexen Psychologie C.G. Jungs English',
+        '810 Series Added Entry: United States Congress House Report',
+        '811 Series Added Entry: Inter-American Conference on Agriculture (3rd : 1945 : Caracas, Venezuela) Cuadernos verdes Serie nacional'
       ])
     })
     it('handles multiple seriesAddedEntry fields correctly', async () => {
@@ -2122,17 +2122,17 @@ describe('EsBib', function () {
     })
     it('concatenates subfields properly for seriesAddedEntry', async () => {
       const result = await esBib.seriesAddedEntry()
-      // 800 field concatenates a, q, d, t, l, v
-      expect(result[0]).to.equal('800 Series Added Entry: Meier, C. A. (Carl Alfred) 1905-1995 Lehrbuch der komplexen Psychologie C.G. Jungs English v. 1')
-      // 810 field concatenates a, b, b, t, v
-      expect(result[1]).to.equal('810 Series Added Entry: United States Congress House Report 112-664')
-      // 811 field concatenates a, n, t, p, v
-      expect(result[2]).to.equal('811 Series Added Entry: Inter-American Conference on Agriculture (3rd : 1945 : Caracas, Venezuela) Cuadernos verdes Serie nacional 14')
+      // 800 field concatenates a, q, d, t, l
+      expect(result[0]).to.equal('800 Series Added Entry: Meier, C. A. (Carl Alfred) 1905-1995 Lehrbuch der komplexen Psychologie C.G. Jungs English')
+      // 810 field concatenates a, b, b, t
+      expect(result[1]).to.equal('810 Series Added Entry: United States Congress House Report')
+      // 811 field concatenates a, n, t, p
+      expect(result[2]).to.equal('811 Series Added Entry: Inter-American Conference on Agriculture (3rd : 1945 : Caracas, Venezuela) Cuadernos verdes Serie nacional')
     })
     it('series_displayPacked returns subfield a||full for 490 fields', () => {
       const result = esBib.series_displayPacked()
       expect(result).to.deep.equal([
-        '490 Series: The Psychology of C.G. Jung||490 Series: The Psychology of C.G. Jung v. 1 (Z965.N38)'
+        '490 Series: The Psychology of C.G. Jung||490 Series: The Psychology of C.G. Jung v. 1 (Z965.N38)', '490 Series: The Psychology of C.G. Jung||490 Series: The Psychology of C.G. Jung v. 2'
       ])
     })
     it('seriesUniformTitle_displayPacked returns all subfields except v||full for 830 fields', () => {
@@ -2144,9 +2144,9 @@ describe('EsBib', function () {
     it('seriesAddedEntry_displayPacked returns name||label for 800/810/811', () => {
       const result = esBib.seriesAddedEntry_displayPacked()
       expect(result).to.deep.equal([
-        '800 Series Added Entry: Meier, C. A. (Carl Alfred) 1905-1995||800 Series Added Entry: Meier, C. A. (Carl Alfred) 1905-1995 Lehrbuch der komplexen Psychologie C.G. Jungs English v. 1',
-        '810 Series Added Entry: United States Congress House||810 Series Added Entry: United States Congress House Report 112-664',
-        '811 Series Added Entry: Inter-American Conference on Agriculture (3rd : 1945 : Caracas, Venezuela)||811 Series Added Entry: Inter-American Conference on Agriculture (3rd : 1945 : Caracas, Venezuela) Cuadernos verdes Serie nacional 14'
+        '800 Series Added Entry: Meier, C. A. (Carl Alfred) 1905-1995 Lehrbuch der komplexen Psychologie C.G. Jungs English||800 Series Added Entry: Meier, C. A. (Carl Alfred) 1905-1995 Lehrbuch der komplexen Psychologie C.G. Jungs English v. 1',
+        '810 Series Added Entry: United States Congress House Report||810 Series Added Entry: United States Congress House Report 112-664',
+        '811 Series Added Entry: Inter-American Conference on Agriculture (3rd : 1945 : Caracas, Venezuela) Cuadernos verdes Serie nacional||811 Series Added Entry: Inter-American Conference on Agriculture (3rd : 1945 : Caracas, Venezuela) Cuadernos verdes Serie nacional 14'
       ])
     })
     it('parallelSeries_displayPacked returns subfield a||full for parallels to 490 field', function () {
@@ -2164,7 +2164,7 @@ describe('EsBib', function () {
     it('parallelSeriesAddedEntry_displayPacked returns subfield a||full for parallels to 800/810/811 (811 in this case) field', function () {
       const result = esBib.parallelSeriesAddedEntry_displayPacked()
       expect(result).to.deep.equal([
-        '811 Series Added Entry parallel: Chakra llamkaymanta Conferencia Interamericana||811 Series Added Entry parallel: Chakra llamkaymanta Conferencia Interamericana Serie nacional nisqa'
+        '811 Series Added Entry parallel: Chakra llamkaymanta Conferencia Interamericana Serie nacional nisqa||811 Series Added Entry parallel: Chakra llamkaymanta Conferencia Interamericana Serie nacional nisqa'
       ])
     })
   })


### PR DESCRIPTION
- no more 800/810/811 (series added entry) handled by browse-term, now their values are just mapped to include all subfields except $v and $0
- handling multiples better (ex. you have two 490s, even though their $a subfields match, there's two distinct display strings because their $v subfields don't match. so series_displayPacked should be returned as an array with two strings) this is what all the deduping flags are allowing