### PR TITLE
Fix nypl-core-objects checkin card status bug

### DIFF
--- a/lib/load-core-data.js
+++ b/lib/load-core-data.js
@@ -6,7 +6,7 @@ const logger = require('./logger')
 const vocabs = {
   accessMessageMapping: 'by-accessMessages',
   catalogItemTypeMapping: 'by-catalog-item-type',
-  checkinCardStatusMapping: 'by-checkin-card-statuses',
+  checkinCardStatusMapping: 'by-checkin-card-status',
   collectionMapping: 'by-collection',
   formatMapping: 'by-formats',
   organizationMapping: 'organizations',

--- a/test/unit/utils-checkin-card-filters.test.js
+++ b/test/unit/utils-checkin-card-filters.test.js
@@ -180,7 +180,6 @@ describe('utils/checkin-card-filters', () => {
     let restoreCachedData
     before(() => {
       restoreCachedData = loadCoreData._private.cache
-      console.log('captured nypl-core as ', restoreCachedData)
 
       loadCoreData._private.setCached({
         checkinCardStatusMapping: {
@@ -192,7 +191,6 @@ describe('utils/checkin-card-filters', () => {
     })
 
     after(async () => {
-      console.log('restoring nypl-core data to ', restoreCachedData)
       loadCoreData._private.setCached(restoreCachedData)
 
       // Other tests depend on this:


### PR DESCRIPTION
Was using the wrong call to nypl-core-objects, causing it to return a basic mapping for checkin-card-statuses, which lacked the critical .status property. Because of this default-response behavior in nypl-core-objects, I don't see a way to cover this with unit tests as we'd be testing the contents of nypl-core.