### PR TITLE
Fix bug with bad checkin card sort

### DIFF
--- a/lib/es-models/checkin-card-item.js
+++ b/lib/es-models/checkin-card-item.js
@@ -4,7 +4,7 @@ const { lookup } = require('../utils/lookup')
 const logger = require('../logger')
 const { HoldingMappings } = require('../mappings/mappings')
 const { parseCheckinCardDate } = require('../utils/checkin-card-date-parse')
-const { arrayToEsRangeObject } = require('../utils/es-ranges')
+const { arrayToEsRangeObject, enumerationChronologySortFromEsRanges } = require('../utils/es-ranges')
 const { parseVolume } = require('../utils/volume-parse')
 const nyplCore = require('../load-core-data')
 const BaseItemMixin = require('./base-item-mixin')
@@ -93,7 +93,11 @@ class EsCheckinCardItem extends BaseItemMixin(EsBase) {
    *  enumeration-chronolgy
    */
   enumerationChronology_sort () {
-    return this.esBib._sortKeyForItem(this)
+    if (process.env.UPDATED_ITEM_SORT === 'true') {
+      return this.esBib._sortKeyForItem(this)
+    } else {
+      return enumerationChronologySortFromEsRanges(this.volumeRange(), this.dateRange())
+    }
   }
 
   /**


### PR DESCRIPTION
New sort requires a feature flag. I overlooked checking that flag for checkin-cards, leading to checkin card items and regular items being sorted using incompatible values.