### PR TITLE
Scc 5238 - Update Notes mappings

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -583,8 +583,7 @@ class EsBib extends EsBase {
       .map(({ varFieldMatchObject, description }, index) => ({
         label: combineLigaturePairs(varFieldMatchObject.value),
         type: 'bf:Note',
-        noteType: description,
-        parallel: varFieldMatchObject.parallel.value
+        noteType: description
       })
       )
   }
@@ -966,8 +965,8 @@ class EsBib extends EsBase {
   _buildNotesArray () {
     // noteType is description, type is bf:Note, label is the value
     const marcTags = BibMappings.get('note', this.bib)
-    return marcTags.map((path) => {
-      // example path:
+    return marcTags.map((config) => {
+      // example config:
       // {
       //   "marc": "501",
       //   "subfields": [
@@ -976,8 +975,8 @@ class EsBib extends EsBase {
       //   "ind1": ["2"],
       //   "description": "With"
       // }
-      return this.bib.varField(path.marc, path.subfields, path.mappingOptions)
-        .map((varFieldMatchObject) => ({ varFieldMatchObject, description: path.description }))
+      return this.bib.varField(config.marc, config.subfields, config)
+        .map((varFieldMatchObject) => ({ varFieldMatchObject, description: config.description }))
     }).filter((varFieldMatches) => {
       // remove empty arrays (no notes for a given marc tag)
       return varFieldMatches.length
@@ -1040,7 +1039,6 @@ class EsBib extends EsBase {
  * @return {array} Array of objects representing electronic resources with following properties:
  * - url: URL of resoruce
  * - label: Label for resource if found
- * - path: "Path" to value in marc (for recording provo)
  */
   _extractElectronicResourcesFromBibMarc (type) {
     // Set up a filter to sort 856 entries into either ER or supplemental:

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -575,11 +575,11 @@ class EsBib extends EsBase {
   }
 
   note () {
-    const notesArray = this._buildNotesArray()
-    if (!notesArray.length) return null
+    const notes = this._buildNotesArray()
+    if (!notes.length) return null
 
     // loop over the content so a separate object is generated for each one.
-    return notesArray
+    return notes
       .map(({ varFieldMatchObject, description }, index) => ({
         label: combineLigaturePairs(varFieldMatchObject.value),
         type: 'bf:Note',
@@ -660,17 +660,18 @@ class EsBib extends EsBase {
   }
 
   parallelNote () {
-    let notesArray = this._buildNotesArray()
+    let notes = this._buildNotesArray()
+    if (!notes) return null
 
     // Remove trailing empty notes:
-    notesArray = removeTrailingElementsMatching(
-      notesArray,
+    notes = removeTrailingElementsMatching(
+      notes,
       ({ varFieldMatchObject }) => !parallelValue(varFieldMatchObject)
     )
 
-    if (!notesArray.length) return null
+    if (!notes.length) return null
 
-    return notesArray
+    return notes
       .map(({ varFieldMatchObject, description }) => {
         const label = parallelValue(varFieldMatchObject)
         if (!label) {
@@ -963,8 +964,6 @@ class EsBib extends EsBase {
    */
   _buildNotesArray () {
     // noteType is description, type is bf:Note, label is the value
-    // get marctags
-    // const values = this._valueToIndexFromBasicMapping('note', primary)
     const marcTags = BibMappings.get('note', this.bib)
     return marcTags.map((path) => {
       // example path:
@@ -973,18 +972,13 @@ class EsBib extends EsBase {
       //   "subfields": [
       //     "a"
       //   ],
+      //   "ind1": ["2"],
       //   "description": "With"
       // }
-      // contentPerMarcTag is an array of objects containing the content and subfieldMap
-      //    for the marc field and subfields supplied by the path.
-      const varFields = this.bib.varField(path.marc, path.subfields, {
-        // For notes, first indicator of '0' means it's suppressed:
-        preFilter: (block) => block.ind1 !== '0'
-      })
-      return varFields
+      return this.bib.varField(path.marc, path.subfields, path)
         .map((varFieldMatchObject) => ({ varFieldMatchObject, description: path.description }))
-      // remove empty arrays (no notes for a given marc tag)
     }).filter((content) => {
+      // remove empty arrays (no notes for a given marc tag)
       return content.length
     }).flat()
   }
@@ -1048,16 +1042,19 @@ class EsBib extends EsBase {
  * - path: "Path" to value in marc (for recording provo)
  */
   _extractElectronicResourcesFromBibMarc (type) {
-    // Set up a filter to apply to 856 fields
-    // Unless `type` set to ER or Appendix, our preFilter accepts all e-resources:
-    let preFilter = () => true
+    // Set up a filter to sort 856 entries into either ER or supplemental:
+    const indicatorFilter = {}
     // Each 856 entry with ind2 of '0' or '1' is a Electronic Resource:
-    if (type === 'complete digital record') preFilter = (marcBlock) => ['0', '1'].indexOf(String(marcBlock.ind2)) >= 0
+    if (type === 'complete digital record') {
+      indicatorFilter.ind2 = ['0', '1']
+    }
     // Each 856 entry with ind2 of '2' (or blank/unset) is "Appendix" (bib.supplementaryContent):
-    if (type === 'supplementary content') preFilter = (marcBlock) => !marcBlock.ind2 || String(marcBlock.ind2).trim() === '' || ['2'].indexOf(String(marcBlock.ind2)) >= 0
+    if (type === 'supplementary content') {
+      indicatorFilter.ind2 = [' ', '2']
+    }
 
     // URLs and labels can be anywhere, so pass `null` subfields param to get them all
-    const electronicStuff = this.bib.varField(856, null, { tagSubfields: true, preFilter })
+    const electronicStuff = this.bib.varField(856, null, { tagSubfields: true, ...indicatorFilter })
 
     if (electronicStuff && electronicStuff.length > 0) {
       return electronicStuff.map(({ subfieldMap }) => {

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -975,7 +975,7 @@ class EsBib extends EsBase {
       //   "ind1": ["2"],
       //   "description": "With"
       // }
-      return this.bib.varField(path.marc, path.subfields, path)
+      return this.bib.varField(path.marc, path.subfields, path.mappingOptions)
         .map((varFieldMatchObject) => ({ varFieldMatchObject, description: path.description }))
     }).filter((content) => {
       // remove empty arrays (no notes for a given marc tag)

--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -583,7 +583,8 @@ class EsBib extends EsBase {
       .map(({ varFieldMatchObject, description }, index) => ({
         label: combineLigaturePairs(varFieldMatchObject.value),
         type: 'bf:Note',
-        noteType: description
+        noteType: description,
+        parallel: varFieldMatchObject.parallel.value
       })
       )
   }
@@ -977,9 +978,9 @@ class EsBib extends EsBase {
       // }
       return this.bib.varField(path.marc, path.subfields, path.mappingOptions)
         .map((varFieldMatchObject) => ({ varFieldMatchObject, description: path.description }))
-    }).filter((content) => {
+    }).filter((varFieldMatches) => {
       // remove empty arrays (no notes for a given marc tag)
-      return content.length
+      return varFieldMatches.length
     }).flat()
   }
 

--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -592,7 +592,7 @@
       },
       {
         "marc": "506",
-        "excludeSubfields": ["6", "7", "2"],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1": [
           " ",
           "1"
@@ -770,7 +770,7 @@
       },
       {
         "marc": "541",
-        "excludeSubfields": ["6", "7", "2"],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1": [
           "1"
         ],
@@ -885,7 +885,7 @@
       },
       {
         "marc": "583",
-        "excludeSubfields": ["6", "7", "2"],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1": ["1"],
         "description": "Processing Action"
       },
@@ -907,25 +907,25 @@
       },
       {
         "marc": "588",
-        "excludeSubfields": ["6", "7", "2"],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1": [" "],
         "description": "Note"
       },
       {
         "marc": "588",
-        "excludeSubfields": ["6", "7", "2"],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Source of Description"
       },
       {
         "marc": "588",
-        "excludeSubfields": ["6", "7", "2"],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1": ["1"],
         "description": "Latest issue consulted"
       },
       {
         "marc": "590",
-        "excludeSubfields": ["6", "7", "2"],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Local note"
       }

--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -563,6 +563,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Note"
       },
       {
@@ -570,6 +571,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "With"
       },
       {
@@ -577,6 +579,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Thesis"
       },
       {
@@ -584,13 +587,17 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Bibliography"
       },
       {
         "marc": "506",
-        "subfields": [
-          "a"
+        "excludeSubfields": ["6", "7", "2"],
+        "ind1": [
+          " ",
+          "1"
         ],
+        "ind1Not": ["0"],
         "description": "Access"
       },
       {
@@ -598,6 +605,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Scale"
       },
       {
@@ -605,6 +613,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Credits"
       },
       {
@@ -612,6 +621,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Indexed In"
       },
       {
@@ -619,6 +629,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Performer"
       },
       {
@@ -626,6 +637,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Type of Report"
       },
       {
@@ -633,6 +645,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Data Quality"
       },
       {
@@ -640,6 +653,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Numbering"
       },
       {
@@ -647,6 +661,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "File Type"
       },
       {
@@ -654,6 +669,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Event"
       },
       {
@@ -661,6 +677,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Audience"
       },
       {
@@ -668,6 +685,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Coverage"
       },
       {
@@ -675,6 +693,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Cite As"
       },
       {
@@ -682,6 +701,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Supplement"
       },
       {
@@ -689,6 +709,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Study Program"
       },
       {
@@ -696,6 +717,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Additional Formats"
       },
       {
@@ -703,6 +725,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Reproduction"
       },
       {
@@ -710,6 +733,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Original Version"
       },
       {
@@ -717,6 +741,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Original Location"
       },
       {
@@ -724,6 +749,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Funding"
       },
       {
@@ -731,6 +757,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "System Details"
       },
       {
@@ -738,15 +765,16 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Terms of Use"
       },
       {
         "marc": "541",
-        "excludedSubfields": [
-          "2",
-          "6",
-          "7"
+        "excludeSubfields": ["6", "7", "2"],
+        "ind1": [
+          "1"
         ],
+        "ind1Not": ["0"],
         "description": "Source"
       },
       {
@@ -754,6 +782,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Information Relating to Copyright Status"
       },
       {
@@ -761,6 +790,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Location of Other Archival Materials"
       },
       {
@@ -769,6 +799,7 @@
           "a",
           "b"
         ],
+        "ind1Not": ["0"],
         "description": "Biography"
       },
       {
@@ -777,6 +808,7 @@
           "a",
           "b"
         ],
+        "ind1Not": ["0"],
         "description": "Language"
       },
       {
@@ -784,6 +816,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Former Title"
       },
       {
@@ -791,6 +824,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Issued By"
       },
       {
@@ -798,6 +832,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Indexes/Finding Aids"
       },
       {
@@ -805,6 +840,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Documentation"
       },
       {
@@ -812,6 +848,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Provenance"
       },
       {
@@ -819,6 +856,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Copy/Version"
       },
       {
@@ -826,6 +864,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Binding"
       },
       {
@@ -833,6 +872,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Linking Entry"
       },
       {
@@ -840,13 +880,13 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Publications"
       },
       {
         "marc": "583",
-        "subfields": [
-          "a"
-        ],
+        "excludeSubfields": ["6", "7", "2"],
+        "ind1": ["1"],
         "description": "Processing Action"
       },
       {
@@ -854,6 +894,7 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Exhibitions"
       },
       {
@@ -861,20 +902,31 @@
         "subfields": [
           "a"
         ],
+        "ind1Not": ["0"],
         "description": "Awards"
       },
       {
         "marc": "588",
-        "subfields": [
-          "a"
-        ],
+        "excludeSubfields": ["6", "7", "2"],
+        "ind1": [" "],
+        "description": "Note"
+      },
+      {
+        "marc": "588",
+        "excludeSubfields": ["6", "7", "2"],
+        "ind1Not": ["0"],
         "description": "Source of Description"
       },
       {
+        "marc": "588",
+        "excludeSubfields": ["6", "7", "2"],
+        "ind1": ["1"],
+        "description": "Latest issue consulted"
+      },
+      {
         "marc": "590",
-        "subfields": [
-          "a"
-        ],
+        "excludeSubfields": ["6", "7", "2"],
+        "ind1Not": ["0"],
         "description": "Local note"
       }
     ]

--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -560,33 +560,25 @@
     "paths": [
       {
         "marc": "500",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Note"
       },
       {
         "marc": "501",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "With"
       },
       {
         "marc": "502",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Thesis"
       },
       {
         "marc": "504",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Bibliography"
       },
@@ -602,169 +594,127 @@
       },
       {
         "marc": "507",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Scale"
       },
       {
         "marc": "508",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Credits"
       },
       {
         "marc": "510",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Indexed In"
       },
       {
         "marc": "511",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Performer"
       },
       {
         "marc": "513",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Type of Report"
       },
       {
         "marc": "514",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Data Quality"
       },
       {
         "marc": "515",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Numbering"
       },
       {
         "marc": "516",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "File Type"
       },
       {
         "marc": "518",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Event"
       },
       {
         "marc": "521",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Audience"
       },
       {
         "marc": "522",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Coverage"
       },
       {
         "marc": "524",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Cite As"
       },
       {
         "marc": "525",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Supplement"
       },
       {
         "marc": "526",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Study Program"
       },
       {
         "marc": "530",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Additional Formats"
       },
       {
         "marc": "533",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Reproduction"
       },
       {
         "marc": "534",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Original Version"
       },
       {
         "marc": "535",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Original Location"
       },
       {
         "marc": "536",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Funding"
       },
       {
         "marc": "538",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "System Details"
       },
       {
         "marc": "540",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Terms of Use"
       },
@@ -779,107 +729,79 @@
       },
       {
         "marc": "542",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Information Relating to Copyright Status"
       },
       {
         "marc": "544",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Location of Other Archival Materials"
       },
       {
         "marc": "545",
-        "subfields": [
-          "a",
-          "b"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Biography"
       },
       {
         "marc": "546",
-        "subfields": [
-          "a",
-          "b"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Language"
       },
       {
         "marc": "547",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Former Title"
       },
       {
         "marc": "550",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Issued By"
       },
       {
         "marc": "555",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Indexes/Finding Aids"
       },
       {
         "marc": "556",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Documentation"
       },
       {
         "marc": "561",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Provenance"
       },
       {
         "marc": "562",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Copy/Version"
       },
       {
         "marc": "563",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Binding"
       },
       {
         "marc": "580",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Linking Entry"
       },
       {
         "marc": "581",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Publications"
       },
@@ -891,17 +813,13 @@
       },
       {
         "marc": "585",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Exhibitions"
       },
       {
         "marc": "586",
-        "subfields": [
-          "a"
-        ],
+        "excludedSubfields": ["6", "7", "2"],
         "ind1Not": ["0"],
         "description": "Awards"
       },

--- a/lib/mappings/mappings.js
+++ b/lib/mappings/mappings.js
@@ -32,18 +32,21 @@ const mappingEntryToMarcQueryObject = (mapping) => {
   // MarcQuery object we return.
   // If either of these properties are set in the mappings json, copy them to
   // the mappingOptions:
-  ; ['excludedSubfields', 'subfieldJoiner']
-    .forEach((optionsProp) => {
+  // ; ['excludedSubfields', 'subfieldJoiner', 'ind1', ']
+  Object.entries(mapping)
+    .forEach(([prop, value]) => {
+      // .forEach((optionsProp) => {
       // If the mappings json defines this option:
-      if (mapping[optionsProp]) {
-        // Initialize returned mappingOptions if not yet set:
-        marcQuery.mappingOptions = marcQuery.mappingOptions || {}
-        // Set option value:
-        marcQuery.mappingOptions[optionsProp] = marcQuery[optionsProp]
-        // Remove option key from the MarcQuery object now that we've nested
-        // it under mappingOptions:
-        delete marcQuery[optionsProp]
-      }
+      // if (mapping[optionsProp]) {
+
+      // Initialize returned mappingOptions if not yet set:
+      marcQuery.mappingOptions = marcQuery.mappingOptions || {}
+      // Set option value:
+      marcQuery.mappingOptions[prop] = marcQuery[prop]
+      // Remove option key from the MarcQuery object now that we've nested
+      // it under mappingOptions:
+      delete marcQuery[prop]
+      // }
     })
 
   return marcQuery

--- a/lib/mappings/mappings.js
+++ b/lib/mappings/mappings.js
@@ -22,37 +22,6 @@ const amendMappingsBasedOnNyplSource = (data, nyplSource) => {
 }
 
 /**
- * Given a raw mapping entry, returns a {MarcQuery} object suitable for passing
- * into SierraBase.varFieldsMulti
- */
-const mappingEntryToMarcQueryObject = (mapping) => {
-  const marcQuery = Object.assign({}, mapping)
-
-  // Some mappings have "options" params that we'd like to relocate in the
-  // MarcQuery object we return.
-  // If either of these properties are set in the mappings json, copy them to
-  // the mappingOptions:
-  // ; ['excludedSubfields', 'subfieldJoiner', 'ind1', ']
-  Object.entries(mapping)
-    .forEach(([prop, value]) => {
-      // .forEach((optionsProp) => {
-      // If the mappings json defines this option:
-      // if (mapping[optionsProp]) {
-
-      // Initialize returned mappingOptions if not yet set:
-      marcQuery.mappingOptions = marcQuery.mappingOptions || {}
-      // Set option value:
-      marcQuery.mappingOptions[prop] = marcQuery[prop]
-      // Remove option key from the MarcQuery object now that we've nested
-      // it under mappingOptions:
-      delete marcQuery[prop]
-      // }
-    })
-
-  return marcQuery
-}
-
-/**
  *
  *  @typedef MappingGetter
  *  @type {function}
@@ -74,7 +43,6 @@ const makeMappingsGetter = (type) => {
     if (!mappingsForRecord[propertyName]) return null
 
     return (mappingsForRecord[propertyName].paths || [])
-      .map(mappingEntryToMarcQueryObject)
   }
 }
 

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -32,7 +32,7 @@ class SierraBase {
 
   fieldTag (field, subfields, opts) {
     const varFields = this._varFieldByFieldTag(field)
-    return this._convertRawFieldToVarFieldMatch(varFields, subfields, opts)
+    return this._convertRawFieldsToVarFieldMatches(varFields, subfields, opts)
   }
 
   ldr () {
@@ -152,7 +152,7 @@ class SierraBase {
     const fieldsWithParallelsAndOrPrimaries = this._fieldsWithParallelsAndOrPrimaries(marc)
 
     // do extraction here after everything is all matched
-    let matches = this._convertRawFieldToVarFieldMatch(fieldsWithParallelsAndOrPrimaries, subfields, opts)
+    let matches = this._convertRawFieldsToVarFieldMatches(fieldsWithParallelsAndOrPrimaries, subfields, opts)
       // Make sure there's either a primary or a parallel value:
       .filter((field) => field.value || field.parallel)
 
@@ -321,80 +321,109 @@ class SierraBase {
    *
    *
    * Given an array of raw varField entries from the Sierra record and the
-   * queries sufields and options, returns VarFieldMatch objects
+   * queried sufields and options, returns VarFieldMatch objects, removing
+   * any entries that don't match criteria
    *
    * @return {VarFieldMatch[]}
    */
-  _convertRawFieldToVarFieldMatch (rawFields, includedSubfields, opts) {
-    opts = opts || {}
+  _convertRawFieldsToVarFieldMatches (rawFields, includedSubfields, opts) {
+    if (!Array.isArray(rawFields) || !rawFields.length) {
+      return []
+    }
+
+    return rawFields
+      .map((field) => this._convertRawFieldToVarFieldMatch(field, includedSubfields, opts))
+      .flat()
+      .filter((m) => m)
+  }
+
+  /**
+   *
+   * Given a single raw varField entry from the Sierra record and the queried
+   * subfields and other qualifying information, returns a single
+   * VarFieldMatch object.
+   *
+   * If the qualifying options (subfields, indicators) cause the field to fail
+   * to match, returns null.
+   *
+   * @return {VarFieldMatch[]}
+   * */
+  _convertRawFieldToVarFieldMatch (field, includedSubfields, opts) {
     opts = Object.assign({
-      preFilter: (block) => true,
       excludedSubfields: [],
       subfieldJoiner: ' ',
-      includeMarc: false
-    }, opts)
+      includeMarc: false,
+      ind1: [],
+      ind1Not: [],
+      ind2: [],
+      ind2Not: []
+    }, opts || {})
 
-    if (Array.isArray(rawFields) && rawFields.length) {
-      const vals = rawFields.filter(opts.preFilter).map((field) => {
-        // Build return:
-        const varFieldMatchReturn = {}
+    // Build return:
+    const varFieldMatchReturn = {}
 
-        // Build value
-        //
-        // If this raw varfield contains any subfields at all (always true, except for orphaned parallels):
-        // (sometimes there's a case error)
-        const unfilteredSubFields = field.subFields || field.subfields
-        if (unfilteredSubFields) {
-          let filteredSubfields = unfilteredSubFields
+    // Abort if fail to match ind1 or ind2 criteria:
+    if (
+      (opts.ind1.length && !opts.ind1.includes(field.ind1)) ||
+      (opts.ind1Not.length && opts.ind1Not.includes(field.ind1)) ||
+      (opts.ind2.length && !opts.ind2.includes(field.ind2)) ||
+      (opts.ind2Not.length && opts.ind2Not.includes(field.ind2))
+    ) {
+      return null
+    }
+    // Build value
+    //
+    // If this raw varfield contains any subfields at all (always true, except for orphaned parallels):
+    // (sometimes there's a case error)
+    const unfilteredSubFields = field.subFields || field.subfields
+    if (unfilteredSubFields) {
+      let filteredSubfields = unfilteredSubFields
 
-          // Apply inclusion/exclusion rules to select desired subfields:
-          if (includedSubfields) {
-            filteredSubfields = filteredSubfields
-              .filter((sub) => includedSubfields.indexOf(sub.tag) >= 0)
-          } else if (opts.excludedSubfields) {
-            filteredSubfields = filteredSubfields
-              .filter((sub) => !opts.excludedSubfields.includes(sub.tag) && sub.tag !== '6')
+      // Apply inclusion/exclusion rules to select desired subfields:
+      if (includedSubfields) {
+        filteredSubfields = filteredSubfields
+          .filter((sub) => includedSubfields.indexOf(sub.tag) >= 0)
+      } else if (opts.excludedSubfields) {
+        filteredSubfields = filteredSubfields
+          .filter((sub) => !opts.excludedSubfields.includes(sub.tag) && sub.tag !== '6')
+      }
+      varFieldMatchReturn.varFieldIndex = field.varFieldIndex
+      varFieldMatchReturn.value = filteredSubfields.map((sub) => sub.content).join(opts.subfieldJoiner)
+      if (opts.includeMarc) varFieldMatchReturn.marc = field
+      varFieldMatchReturn.subfieldMap = filteredSubfields.reduce((hash, sub) => {
+        // If there are multiple values for this tag, convert it into an array:
+        if (hash[sub.tag]) {
+          if (typeof hash[sub.tag] === 'string') {
+            hash[sub.tag] = [hash[sub.tag]]
           }
-          varFieldMatchReturn.varFieldIndex = field.varFieldIndex
-          varFieldMatchReturn.value = filteredSubfields.map((sub) => sub.content).join(opts.subfieldJoiner)
-          if (opts.includeMarc) varFieldMatchReturn.marc = field
-          varFieldMatchReturn.subfieldMap = filteredSubfields.reduce((hash, sub) => {
-            // If there are multiple values for this tag, convert it into an array:
-            if (hash[sub.tag]) {
-              if (typeof hash[sub.tag] === 'string') {
-                hash[sub.tag] = [hash[sub.tag]]
-              }
-              hash[sub.tag].push(sub.content)
-            } else {
-              hash[sub.tag] = sub.content
-            }
-            return hash
-          }, {})
-        } else if (field.content) {
-          varFieldMatchReturn.value = field.content
+          hash[sub.tag].push(sub.content)
+        } else {
+          hash[sub.tag] = sub.content
         }
+        return hash
+      }, {})
+    } else if (field.content) {
+      varFieldMatchReturn.value = field.content
+    }
 
-        // Trim trailing punctuation:
-        if (varFieldMatchReturn.value) {
-          varFieldMatchReturn.value = trimTrailingPunctuation(varFieldMatchReturn.value)
-        }
+    // Trim trailing punctuation:
+    if (varFieldMatchReturn.value) {
+      varFieldMatchReturn.value = trimTrailingPunctuation(varFieldMatchReturn.value)
+    }
 
-        // Build parallel:
-        if (field.parallel) {
-          const subfield6 = this._parseSubfield6(field.parallel)
-          // coerce parallel into array for the purpose of recursive call
-          varFieldMatchReturn.parallel = this._convertRawFieldToVarFieldMatch([field.parallel], includedSubfields, opts)[0]
-          if (varFieldMatchReturn.parallel && subfield6) {
-            varFieldMatchReturn.parallel.script = subfield6.script
-            varFieldMatchReturn.parallel.direction = subfield6.direction
-            if (opts.includeMarc) varFieldMatchReturn.parallel.marc = field.parallel
-          }
-        }
+    // Build parallel:
+    if (field.parallel) {
+      const subfield6 = this._parseSubfield6(field.parallel)
+      // coerce parallel into array for the purpose of recursive call
+      varFieldMatchReturn.parallel = this._convertRawFieldToVarFieldMatch(field.parallel, includedSubfields, opts)
+      if (varFieldMatchReturn.parallel && subfield6) {
+        varFieldMatchReturn.parallel.script = subfield6.script
+        varFieldMatchReturn.parallel.direction = subfield6.direction
+        if (opts.includeMarc) varFieldMatchReturn.parallel.marc = field.parallel
+      }
+    }
 
-        return varFieldMatchReturn
-      })
-      return [].concat.apply([], vals).filter((v) => v)
-    } else return []
+    return varFieldMatchReturn
   }
 
   _parseParallelFieldLink (subfield6) {

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -128,7 +128,7 @@ class SierraBase {
    * @property {function} preFilter - Optional function to filter out matching
    *   marc blocks before extracting value. Useful for checking atypical
    *   properties like `ind1`.
-   * @property {string[]} excludeSubfields - Optional array identifying
+   * @property {string[]} excludedSubfields - Optional array identifying
    *   subfields that should be excluded (e.g. ['0', '6'])
    * @property {boolean} dedupe - Optional boolean indicating whether return
    *   should de-deupe entries that have matching primary and parallel values.

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -149,6 +149,7 @@ class SierraBase {
     opts = Object.assign({
       dedupe: true
     }, opts)
+    console.log('varField opts: ', opts)
     const fieldsWithParallelsAndOrPrimaries = this._fieldsWithParallelsAndOrPrimaries(marc)
 
     // do extraction here after everything is all matched
@@ -362,15 +363,26 @@ class SierraBase {
     // Build return:
     const varFieldMatchReturn = {}
 
+    // Gather ind1 and ind2 values, falling back on parallel values
+    // (mainly to support orphaned parallels)
+    const ind1 = field.ind1 || field.parallel?.ind1
+    const ind2 = field.ind2 || field.parallel?.ind2
+
+    const interesting = ind1 === '0'
+
+    console.log('Applying field filter: ', opts)
     // Abort if fail to match ind1 or ind2 criteria:
     if (
-      (opts.ind1.length && !opts.ind1.includes(field.ind1)) ||
-      (opts.ind1Not.length && opts.ind1Not.includes(field.ind1)) ||
-      (opts.ind2.length && !opts.ind2.includes(field.ind2)) ||
-      (opts.ind2Not.length && opts.ind2Not.includes(field.ind2))
+      (opts.ind1.length && !opts.ind1.includes(ind1)) ||
+      (opts.ind1Not.length && opts.ind1Not.includes(ind1)) ||
+      (opts.ind2.length && !opts.ind2.includes(ind2)) ||
+      (opts.ind2Not.length && opts.ind2Not.includes(ind2))
     ) {
+      if (interesting) console.log('Removing field because ', ind1)
       return null
     }
+    if (interesting) console.log('Keeping field because ', ind1)
+
     // Build value
     //
     // If this raw varfield contains any subfields at all (always true, except for orphaned parallels):
@@ -378,6 +390,7 @@ class SierraBase {
     const unfilteredSubFields = field.subFields || field.subfields
     if (unfilteredSubFields) {
       let filteredSubfields = unfilteredSubFields
+      console.log('opts: ', opts.ind1)
 
       // Apply inclusion/exclusion rules to select desired subfields:
       if (includedSubfields) {
@@ -415,6 +428,7 @@ class SierraBase {
     if (field.parallel) {
       const subfield6 = this._parseSubfield6(field.parallel)
       // coerce parallel into array for the purpose of recursive call
+      console.log('applying parallel convert: ', opts)
       varFieldMatchReturn.parallel = this._convertRawFieldToVarFieldMatch(field.parallel, includedSubfields, opts)
       if (varFieldMatchReturn.parallel && subfield6) {
         varFieldMatchReturn.parallel.script = subfield6.script

--- a/lib/sierra-models/base.js
+++ b/lib/sierra-models/base.js
@@ -149,7 +149,6 @@ class SierraBase {
     opts = Object.assign({
       dedupe: true
     }, opts)
-    console.log('varField opts: ', opts)
     const fieldsWithParallelsAndOrPrimaries = this._fieldsWithParallelsAndOrPrimaries(marc)
 
     // do extraction here after everything is all matched
@@ -260,7 +259,7 @@ class SierraBase {
    */
   varFieldsMulti (marcObjects, includeMarc = false, dedupe = true) {
     let matches = marcObjects
-      .map(({ marc, subfields, mappingOptions }) => {
+      .map(({ marc, subfields, ...mappingOptions }) => {
         const options = Object.assign({}, mappingOptions, { dedupe: false, includeMarc })
         return this.varField(marc, subfields, options)
       })
@@ -368,9 +367,6 @@ class SierraBase {
     const ind1 = field.ind1 || field.parallel?.ind1
     const ind2 = field.ind2 || field.parallel?.ind2
 
-    const interesting = ind1 === '0'
-
-    console.log('Applying field filter: ', opts)
     // Abort if fail to match ind1 or ind2 criteria:
     if (
       (opts.ind1.length && !opts.ind1.includes(ind1)) ||
@@ -378,10 +374,8 @@ class SierraBase {
       (opts.ind2.length && !opts.ind2.includes(ind2)) ||
       (opts.ind2Not.length && opts.ind2Not.includes(ind2))
     ) {
-      if (interesting) console.log('Removing field because ', ind1)
       return null
     }
-    if (interesting) console.log('Keeping field because ', ind1)
 
     // Build value
     //
@@ -390,7 +384,6 @@ class SierraBase {
     const unfilteredSubFields = field.subFields || field.subfields
     if (unfilteredSubFields) {
       let filteredSubfields = unfilteredSubFields
-      console.log('opts: ', opts.ind1)
 
       // Apply inclusion/exclusion rules to select desired subfields:
       if (includedSubfields) {
@@ -428,7 +421,6 @@ class SierraBase {
     if (field.parallel) {
       const subfield6 = this._parseSubfield6(field.parallel)
       // coerce parallel into array for the purpose of recursive call
-      console.log('applying parallel convert: ', opts)
       varFieldMatchReturn.parallel = this._convertRawFieldToVarFieldMatch(field.parallel, includedSubfields, opts)
       if (varFieldMatchReturn.parallel && subfield6) {
         varFieldMatchReturn.parallel.script = subfield6.script

--- a/scripts/bulk-index.js
+++ b/scripts/bulk-index.js
@@ -545,7 +545,6 @@ const readCursorRecurser = async (batchSize, cursor, retry = 1) => {
     throw new Error('Error connecting to db after 3 tries')
   }
   try {
-    await delay(retry * 1000)
     return await cursor.read(batchSize)
   } catch (e) {
     logger.warn('readCursorRecursor error: ', e)

--- a/test/unit/browse-term.test.js
+++ b/test/unit/browse-term.test.js
@@ -1,3 +1,4 @@
+/*
 const { expect } = require('chai')
 const sinon = require('sinon')
 const fs = require('fs')
@@ -90,3 +91,4 @@ describe('emitBrowseTerms', () => {
     })
   })
 })
+*/

--- a/test/unit/browse-term.test.js
+++ b/test/unit/browse-term.test.js
@@ -1,4 +1,3 @@
-/*
 const { expect } = require('chai')
 const sinon = require('sinon')
 const fs = require('fs')
@@ -91,4 +90,3 @@ describe('emitBrowseTerms', () => {
     })
   })
 })
-*/

--- a/test/unit/es-base.test.js
+++ b/test/unit/es-base.test.js
@@ -13,6 +13,7 @@ describe('EsBase', function () {
       expect(bib._valueToIndexFromBasicMapping(field, primary)).to.deep.equal(['Sefer Toldot Yeshu = The gospel according to the Jews, called Toldoth Jesu : the generations of Jesus, now first translated from the Hebrew.'
       ])
     })
+
     it('should return array of parallel titles', function () {
       const record = new SierraBib(require('../fixtures/bib-11606020.json'))
       const esBib = new EsBib(record)

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1002,7 +1002,7 @@ describe('EsBib', function () {
           type: 'bf:Note'
         },
         {
-          label: 'Finding aid',
+          label: 'Finding aid: folder level control.',
           type: 'bf:Note',
           noteType: 'Indexes/Finding Aids'
         },
@@ -1037,6 +1037,20 @@ describe('EsBib', function () {
       expect(esBib.note().map((n) => n.label)).to.deep.equal([
         'h content z content'
       ])
+    })
+
+    it('requires ind1=1 for 583', () => {
+      const record = new SierraBib({
+        varFields: [
+          {
+            marcTag: '583',
+            ind1: ' ',
+            subfields: [{ tag: 'a', content: 'a content' }]
+          }
+        ]
+      })
+      const esBib = new EsBib(record)
+      expect(esBib.note()).to.equal(null)
     })
 
     it('parallel notes', () => {
@@ -1091,6 +1105,30 @@ describe('EsBib', function () {
       const note = esBib.note()
       console.log({ note })
       expect(note).to.equal(null)
+    })
+
+    it('includes all subfields', () => {
+      const record = new SierraBib({
+        varFields: [
+          {
+            marcTag: '500',
+            subfields: [
+              { tag: 'a', content: '$a' },
+              { tag: 'b', content: '$b' },
+              { tag: 'z', content: '$c' },
+              { tag: '2', content: '$2' },
+              { tag: '6', content: '$1' }
+            ]
+          }
+        ]
+      })
+      expect((new EsBib(record)).note()).to.deep.equal([
+        {
+          label: '$a $b $c',
+          noteType: 'Note',
+          type: 'bf:Note'
+        }
+      ])
     })
   })
 

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1084,11 +1084,13 @@ describe('EsBib', function () {
       ])
     })
 
-    it.only('excludes parallel notes with 1st indicator 0', () => {
+    it('excludes parallel notes with 1st indicator 0', () => {
       const record = new SierraBib(require('../fixtures/bib-pul-99122517373506421.json'))
       const esBib = new EsBib(record)
       // This record has a single note with 1st indicator '0', so it is excluded:
-      expect(esBib.note()).to.equal(null)
+      const note = esBib.note()
+      console.log({ note })
+      expect(note).to.equal(null)
     })
   })
 
@@ -1118,17 +1120,18 @@ describe('EsBib', function () {
   })
 
   describe('publisherLiteral', () => {
-    const record = new SierraBib(require('../fixtures/bib-10001936.json'))
-    const esBib = new EsBib(record)
     it('should return array with publisherLiteral', function () {
       const record = new SierraBib(require('../fixtures/bib-10001936.json'))
       const esBib = new EsBib(record)
       expect(esBib.publisherLiteral()).to.deep.equal(['Tparan Hovhannu Tēr-Abrahamian'])
     })
     it('parallelPublisherLiteral', () => {
+      const record = new SierraBib(require('../fixtures/bib-10001936.json'))
+      const esBib = new EsBib(record)
       expect(esBib.parallelPublisherLiteral()).to.deep.equal(['parallel for Tparan Hovhannu Tēr-Abrahamian'])
     })
   })
+
   describe('tableOfContents', () => {
     it('should return table of contents', function () {
       const record = new SierraBib(require('../fixtures/bib-11055155.json'))
@@ -1183,8 +1186,13 @@ describe('EsBib', function () {
   })
 
   describe('uniformTitle', () => {
-    const record = new SierraBib(require('../fixtures/bib-11606020.json'))
-    const esBib = new EsBib(record)
+    let esBib
+
+    before(() => {
+      const record = new SierraBib(require('../fixtures/bib-11606020.json'))
+      esBib = new EsBib(record)
+    })
+
     it('should return display titles', function () {
       expect(esBib.uniformTitle()).to.deep.equal(
         ['Toledot Yeshu.']

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1018,6 +1018,27 @@ describe('EsBib', function () {
         }
       ])
     })
+
+    it('includes all but excluded subfields for 506', () => {
+      const record = new SierraBib({
+        varFields: [
+          {
+            marcTag: '506',
+            ind1: ' ',
+            subfields: [
+              { tag: 'h', content: 'h content' },
+              { tag: '2', content: '2 content' },
+              { tag: 'z', content: 'z content' }
+            ]
+          }
+        ]
+      })
+      const esBib = new EsBib(record)
+      expect(esBib.note().map((n) => n.label)).to.deep.equal([
+        'h content z content'
+      ])
+    })
+
     it('parallel notes', () => {
       const record = new SierraBib(require('../fixtures/bib-notes.json'))
       const esBib = new EsBib(record)
@@ -1063,7 +1084,7 @@ describe('EsBib', function () {
       ])
     })
 
-    it('excludes parallel notes with 1st indicator 0', () => {
+    it.only('excludes parallel notes with 1st indicator 0', () => {
       const record = new SierraBib(require('../fixtures/bib-pul-99122517373506421.json'))
       const esBib = new EsBib(record)
       // This record has a single note with 1st indicator '0', so it is excluded:

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1063,7 +1063,7 @@ describe('EsBib', function () {
       ])
     })
 
-    it('excludes notes with 1st indicator 0', () => {
+    it('excludes parallel notes with 1st indicator 0', () => {
       const record = new SierraBib(require('../fixtures/bib-pul-99122517373506421.json'))
       const esBib = new EsBib(record)
       // This record has a single note with 1st indicator '0', so it is excluded:
@@ -1263,7 +1263,7 @@ describe('EsBib', function () {
         'Social security -- Law and legislation -- Uruguay',
         'Social security -- Latin America'
       ])
-      // Expect the root subject to only occur once:
+      // Expect the root subject to oonlynly occur onte:
       expect(record.subjectLiteral_exploded()).to.deep.equal([
         'Social security',
         'Social security -- Law and legislation',
@@ -1750,6 +1750,7 @@ describe('EsBib', function () {
         ]
       })
       const esRecord = new EsBib(record)
+      expect(esRecord.supplementaryContent()).to.be.a('array')
       expect(esRecord.supplementaryContent().length).to.equal(1)
       expect(esRecord.numElectronicResources()).to.deep.equal([2])
       expect(esRecord._aeonUrls().length).to.equal(1)

--- a/test/unit/es-bib.test.js
+++ b/test/unit/es-bib.test.js
@@ -1103,7 +1103,6 @@ describe('EsBib', function () {
       const esBib = new EsBib(record)
       // This record has a single note with 1st indicator '0', so it is excluded:
       const note = esBib.note()
-      console.log({ note })
       expect(note).to.equal(null)
     })
 
@@ -1330,7 +1329,7 @@ describe('EsBib', function () {
         'Social security -- Law and legislation -- Uruguay',
         'Social security -- Latin America'
       ])
-      // Expect the root subject to oonlynly occur onte:
+      // Expect the root subject to only occur once:
       expect(record.subjectLiteral_exploded()).to.deep.equal([
         'Social security',
         'Social security -- Law and legislation',

--- a/test/unit/es-checkin-card-item.test.js
+++ b/test/unit/es-checkin-card-item.test.js
@@ -7,10 +7,15 @@ const EsBib = require('../../lib/es-models/bib')
 const SierraBib = require('../../lib/sierra-models/bib')
 
 describe('EsCheckinCardItem', function () {
-  const holding = new SierraHolding(require('../fixtures/holding-1032862.json'))
-  const record = new SierraBib(require('../fixtures/bib-10001936.json'))
-  const esBib = new EsBib(record)
-  const checkinCardItems = EsCheckinCardItem.fromSierraHolding(holding, esBib)
+  let esBib
+  let checkinCardItems
+
+  before(() => {
+    const holding = new SierraHolding(require('../fixtures/holding-1032862.json'))
+    const record = new SierraBib(require('../fixtures/bib-10001936.json'))
+    esBib = new EsBib(record)
+    checkinCardItems = EsCheckinCardItem.fromSierraHolding(holding, esBib)
+  })
 
   describe('accessMessage', () => {
     it('returns static access message', () => {
@@ -82,8 +87,12 @@ describe('EsCheckinCardItem', function () {
   })
 
   describe('enumerationChronology_sort', () => {
-    const holding = new SierraHolding(require('../fixtures/holding-1044923.json'))
-    const items = EsCheckinCardItem.fromSierraHolding(holding, esBib)
+    let items
+
+    before(() => {
+      const holding = new SierraHolding(require('../fixtures/holding-1044923.json'))
+      items = EsCheckinCardItem.fromSierraHolding(holding, esBib)
+    })
 
     before(() => {
       const sortKeys = { 'i-h1044923-0': '      1' }

--- a/test/unit/es-item.test.js
+++ b/test/unit/es-item.test.js
@@ -241,7 +241,7 @@ describe('EsItem', function () {
   })
 
   describe('physicalLocation', function () {
-    describe('nypl item with location', function () {
+    it('nypl item with location', function () {
       const record = new SierraItem(require('../fixtures/item-17145801.json'))
       const esItem = new EsItem(record)
       expect(esItem.physicalLocation()).to.deep.equal(

--- a/test/unit/mappings.test.js
+++ b/test/unit/mappings.test.js
@@ -155,7 +155,7 @@ describe('mappings', function () {
     it('returns a function that returns subfields specified in mappings.json', () => {
       const bib = new SierraBib(require('../fixtures/bib-11055155.json'))
       const mappings = BibMappings.get('contentsTitle', bib)
-      const subfields = mappings.map(marcField => marcField.subfields).flat()
+      const subfields = mappings.map((marcField) => marcField.subfields).flat()
       // This marcfield for this bib also has subfields g and r, which are not
       // included in bib-mappings.json
       expect(subfields).to.deep.equal(['t'])

--- a/test/unit/sierra-base.test.js
+++ b/test/unit/sierra-base.test.js
@@ -261,6 +261,75 @@ describe('SierraBase', function () {
       expect(varField100[0].value).to.equal('$a content')
       expect(varField100[0].parallel.value).to.equal('$a parallel content')
     })
+
+    describe('indicator querying', () => {
+      // Contrive a record with 3 varfield 100 entries, two of them effectively dupes
+      const record = new SierraBase({
+        varFields: [
+          {
+            marcTag: '100',
+            subfields: [{ tag: 'a', content: '$a content 1' }],
+            ind1: '0'
+          },
+          {
+            marcTag: '100',
+            subfields: [{ tag: 'a', content: '$a content 2' }],
+            ind1: '1'
+          },
+          {
+            marcTag: '880',
+            subfields: [
+              { tag: 'a', content: '$a parallel content 1' },
+              { tag: '6', content: '100-00' }
+            ],
+            ind1: '2'
+          }
+        ]
+      })
+
+      it('matches fields with requested indicators', () => {
+        let v = record.varField(100, ['a'], { ind1: ['0'] })
+        expect(v).to.be.a('array').to.have.lengthOf(1)
+        expect(v[0]).to.deep.include({ value: '$a content 1' })
+
+        v = record.varField(100, ['a'], { ind1: ['1'] })
+        expect(v).to.be.a('array').to.have.lengthOf(1)
+        expect(v[0]).to.deep.include({ value: '$a content 2' })
+
+        v = record.varField(100, ['a'], { ind1: ['0', '1'] })
+        expect(v).to.be.a('array').to.have.lengthOf(2)
+        expect(v[0]).to.deep.include({ value: '$a content 1' })
+        expect(v[1]).to.deep.include({ value: '$a content 2' })
+      })
+
+      it('excludes fields with negated indicators', () => {
+        let v = record.varField(100, ['a'], { ind1Not: ['0', '2'] })
+        expect(v).to.be.a('array').to.have.lengthOf(1)
+        expect(v[0]).to.deep.include({ value: '$a content 2' })
+
+        v = record.varField(100, ['a'], { ind1Not: ['1'] })
+        console.log(JSON.stringify(v, null, 2))
+        expect(v).to.be.a('array').to.have.lengthOf(2)
+        expect(v[0]).to.deep.include({ value: '$a content 1' })
+
+        v = record.varField(100, ['a'], { ind1Not: ['0', '1'] })
+        expect(v).to.be.a('array').to.have.lengthOf(1)
+      })
+
+      it('includes parallel fields by indicators', () => {
+        const v = record.varField(100, ['a'], { ind1: ['2'] })
+        expect(v).to.be.a('array').to.have.lengthOf(1)
+        expect(v[0].parallel).to.be.a('object')
+        expect(v[0].parallel).to.deep.include({ value: '$a parallel content 1' })
+      })
+
+      it('excludes parallel fields with negated indicators', () => {
+        const v = record.varField(100, ['a'], { ind1Not: ['2'] })
+        expect(v).to.be.a('array').to.have.lengthOf(2)
+        expect(v[0]).to.deep.include({ value: '$a content 1' })
+        expect(v[1]).to.deep.include({ value: '$a content 2' })
+      })
+    })
   })
 
   describe('varFieldsMulti', () => {

--- a/test/unit/sierra-base.test.js
+++ b/test/unit/sierra-base.test.js
@@ -308,7 +308,6 @@ describe('SierraBase', function () {
         expect(v[0]).to.deep.include({ value: '$a content 2' })
 
         v = record.varField(100, ['a'], { ind1Not: ['1'] })
-        console.log(JSON.stringify(v, null, 2))
         expect(v).to.be.a('array').to.have.lengthOf(2)
         expect(v[0]).to.deep.include({ value: '$a content 1' })
 


### PR DESCRIPTION
Updated all notes mappings to match webpub.def. Includes refactor of how notes are built to use new support for `ind1`, `ind2`, `ind1Not`, and `ind2Not` mapping options.

Also:
 - Dropping support for `preFilter` param to `varField` since it was only ever used for `ind` filtering, which now has a proper interface. 
   - Updated the things that were previously using `preFilter`
 - Small change to mappings.js interface - now flatter without
   `mappingOptions` concept
 - Remove 1s delay between bulk-index batch processing, since I see no
   purpose and it slows tests
 - Fix a few structural issues with unrelated tests (`describe` that should be an `it`, code running outside `before` hook)

https://newyorkpubliclibrary.atlassian.net/browse/SCC-5238
https://newyorkpubliclibrary.atlassian.net/browse/SCC-5237