### PR TITLE
Add logic for including copy number in shelfmark

### DIFF
--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -236,7 +236,11 @@ class EsItem extends BaseItemMixin(EsBase) {
 
   // ToDO: getting callnum from bib
   shelfMark () {
-    const callnum = this._callNum()
+    let callnum = this._callNum()
+    // check if this is a copy:
+    if (callnum && this.item.fixedFields && this.item.fixedFields['58'] && parseInt(this.item.fixedFields['58'].value, 10) !== 1) {
+      callnum += ` copy ${this.item.fixedFields['58'].value}`
+    }
     return callnum ? [callnum] : null
   }
 

--- a/test/fixtures/item-42330197.json
+++ b/test/fixtures/item-42330197.json
@@ -1,0 +1,225 @@
+{
+    "id": "42330197",
+    "nyplType": "item",
+    "updatedDate": "2026-03-30T17:30:58-04:00",
+    "createdDate": "2026-03-04T19:14:23-05:00",
+    "deletedDate": null,
+    "deleted": false,
+    "location": {
+      "code": "pad38",
+      "name": "Performing Arts Research Collections - Dance"
+    },
+    "status": {
+      "code": "-",
+      "display": "AVAILABLE",
+      "duedate": null
+    },
+    "barcode": "33433123609079",
+    "callNumber": "*MGZPA JRDD 1972 1",
+    "itemType": null,
+    "fixedFields": {
+      "57": {
+        "label": "",
+        "value": "false",
+        "display": null
+      },
+      "58": {
+        "label": "Copy No.",
+        "value": "2",
+        "display": null
+      },
+      "59": {
+        "label": "Item Code 1",
+        "value": "0",
+        "display": null
+      },
+      "60": {
+        "label": "Item Code 2",
+        "value": "-",
+        "display": null
+      },
+      "61": {
+        "label": "Item Type",
+        "value": "15",
+        "display": "flat graphic"
+      },
+      "62": {
+        "label": "Price",
+        "value": "0.000000",
+        "display": null
+      },
+      "64": {
+        "label": "Checkout Location",
+        "value": "0",
+        "display": null
+      },
+      "70": {
+        "label": "Checkin Location",
+        "value": "0",
+        "display": null
+      },
+      "74": {
+        "label": "Item Use 3",
+        "value": "0",
+        "display": null
+      },
+      "76": {
+        "label": "Total Checkouts",
+        "value": "0",
+        "display": null
+      },
+      "77": {
+        "label": "Total Renewals",
+        "value": "0",
+        "display": null
+      },
+      "79": {
+        "label": "Location",
+        "value": "pad38",
+        "display": "Performing Arts Research Collections - Dance"
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "i",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "42330197",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2026-03-04T19:14:23Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2026-03-30T17:30:58Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "4",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": "53rd Street"
+      },
+      "88": {
+        "label": "Status",
+        "value": "-",
+        "display": "AVAILABLE"
+      },
+      "93": {
+        "label": "Inhouse Use",
+        "value": "0",
+        "display": null
+      },
+      "94": {
+        "label": "Copy Use",
+        "value": "0",
+        "display": null
+      },
+      "97": {
+        "label": "Item Message",
+        "value": "u",
+        "display": null
+      },
+      "98": {
+        "label": "",
+        "value": "2026-03-09T19:58:28Z",
+        "display": null
+      },
+      "108": {
+        "label": "OPAC Message",
+        "value": "u",
+        "display": "SUPERVISED USE"
+      },
+      "109": {
+        "label": "Year-to-Date Circ",
+        "value": "0",
+        "display": null
+      },
+      "110": {
+        "label": "Last Year Circ",
+        "value": "0",
+        "display": null
+      },
+      "127": {
+        "label": "Item Agency",
+        "value": "58",
+        "display": "LPA Research"
+      },
+      "161": {
+        "label": "VI Central",
+        "value": "0",
+        "display": null
+      },
+      "162": {
+        "label": "IR Dist Learn Same Site",
+        "value": "0",
+        "display": null
+      },
+      "264": {
+        "label": "Holdings Item Tag",
+        "value": "6",
+        "display": null
+      },
+      "265": {
+        "label": "Inherit Location",
+        "value": "false",
+        "display": null
+      },
+      "306": {
+        "label": "Sticky Status",
+        "value": "",
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "b",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "33433123609079",
+        "subfields": null
+      },
+      {
+        "fieldTag": "c",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "*MGZPA JRDD 1972 1"
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "CATRL/aml",
+        "subfields": null
+      },
+      {
+        "fieldTag": "x",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "AEON eligible LPADN",
+        "subfields": null
+      }
+    ],
+    "nyplSource": "sierra-nypl",
+    "bibIds": [
+      "23879893"
+    ]
+  }

--- a/test/unit/es-item.test.js
+++ b/test/unit/es-item.test.js
@@ -190,6 +190,18 @@ describe('EsItem', function () {
         )
       })
     })
+
+    describe('for an item with callNumber and copy number', function () {
+      it('should return the call number with copy number', function () {
+        const record = new SierraItem(require('../fixtures/item-42330197.json'))
+        const esItem = new EsItem(record)
+        expect(esItem.shelfMark()).to.deep.equal(
+          [
+            '*MGZPA JRDD 1972 1 copy 2'
+          ]
+        )
+      })
+    })
   })
 
   describe('shelfMark_sort', function () {


### PR DESCRIPTION
When item fixed 58 (“Copy No.”) is present and not “1”, append the copy number to the indexed item shelfmark like this: “{shelfmark} copy {C}”. Also adds a test