### PR TITLE
Add hd: prefix to HD customer codes

### DIFF
--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -200,6 +200,11 @@ class EsItem extends BaseItemMixin(EsBase) {
       literal = item._recapCustomerCode
     } else if (!item.isNyplRecord()) {
       literal = item.varField('900', ['b'])[0]?.value
+
+      // To ensure uniqueness of code, prefix alternate depository codes:
+      if (item._depository() && item._depository() !== 'recap') {
+        literal = `${item._depository()}:${literal}`
+      }
     }
 
     if (literal) return [literal]

--- a/lib/sierra-models/item.js
+++ b/lib/sierra-models/item.js
@@ -100,6 +100,31 @@ class SierraItem extends SierraBase {
   }
 
   /**
+   *  Return true if item is offsite
+   */
+  _isOffsite () {
+    if (this.isPartnerRecord()) return true
+    return this.location?.code && /^loc:rc/.test(this.location.code)
+  }
+
+  /**
+   *  Return the offsite depository for this item, if any
+   */
+  _depository () {
+    if (!this._isOffsite()) return null
+
+    let depository = 'recap'
+    // The only partner with an alternate depository is HL:
+    if (this.nyplSource === 'recap-hl') {
+      const _depository = this.varField('852', ['c'])[0]?.value
+      if (_depository.toLowerCase() === 'hd') {
+        depository = 'hd'
+      }
+    }
+    return depository
+  }
+
+  /**
    *  Return true if Item Type is tagged Research in NYPL-Core, implying this
    *  item is Research
    */

--- a/test/fixtures/item-hl-231730577470003941.json
+++ b/test/fixtures/item-hl-231730577470003941.json
@@ -1,0 +1,332 @@
+{
+  "id": "231730577470003941",
+  "nyplType": "item",
+  "updatedDate": "2021-07-28T11:42:08-04:00",
+  "createdDate": null,
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "GUT",
+    "name": "OFFSITE - Request In Advance - hl"
+  },
+  "status": {
+    "code": "-",
+    "display": "AVAILABLE",
+    "duedate": null
+  },
+  "barcode": "GUT0P3H",
+  "callNumber": "QA535",
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": false,
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": "",
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": null,
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": null,
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "55",
+      "display": null
+    },
+    "62": {
+      "label": "Price",
+      "value": null,
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": null,
+      "display": null
+    },
+    "68": {
+      "label": "Last Checkin",
+      "value": null,
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": null,
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": null,
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": null,
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": null,
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "rchl",
+      "display": "OFFSITE - Request In Advance"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "231730577470003941",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": null,
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2021-07-28T11:42:08Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": null,
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "209",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "-",
+      "display": "AVAILABLE"
+    },
+    "93": {
+      "label": "Internal Use",
+      "value": null,
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": null,
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": null,
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": null,
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "2",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": null,
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": null,
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "209",
+      "display": "ReCAP - (DEFAULT)"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": null,
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": null,
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": null,
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": null,
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": null,
+      "marcTag": "876",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "p",
+          "content": "GUT0P3H"
+        },
+        {
+          "tag": "h",
+          "content": ""
+        },
+        {
+          "tag": "a",
+          "content": "231730577470003941"
+        },
+        {
+          "tag": "j",
+          "content": "Available"
+        },
+        {
+          "tag": "t",
+          "content": ""
+        },
+        {
+          "tag": "3",
+          "content": ""
+        },
+        {
+          "tag": "l",
+          "content": "RECAP"
+        },
+        {
+          "tag": "k",
+          "content": "GUT"
+        }
+      ]
+    },
+    {
+      "fieldTag": "a",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "QA535"
+        },
+        {
+          "tag": "c",
+          "content": ""
+        },
+        {
+          "tag": "g",
+          "content": ""
+        },
+        {
+          "tag": "i",
+          "content": "GUT0P3H"
+        },
+        {
+          "tag": "l",
+          "content": "rchl"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": null
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "GUT0P3H",
+      "subfields": null
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "",
+      "subfields": null
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "900",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Shared"
+        },
+        {
+          "tag": "b",
+          "content": "HV"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "852",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "b",
+          "content": "GUT"
+        },
+        {
+          "tag": "c",
+          "content": "RD"
+        },
+        {
+          "tag": "h",
+          "content": "QA535"
+        },
+        {
+          "tag": "i",
+          "content": ".P36 1930"
+        },
+        {
+          "tag": "8",
+          "content": "221730577480003941"
+        }
+      ]
+    }
+  ],
+  "nyplSource": "recap-hl",
+  "bibIds": [
+    "990000028310203941"
+  ]
+}

--- a/test/fixtures/item-hl-231911262430003941.json
+++ b/test/fixtures/item-hl-231911262430003941.json
@@ -1,0 +1,328 @@
+ {
+  "id": "231911262430003941",
+  "nyplType": "item",
+  "updatedDate": "2022-06-27T03:54:29-04:00",
+  "createdDate": null,
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "LAW",
+    "name": "OFFSITE - Request In Advance - hl"
+  },
+  "status": {
+    "code": "-",
+    "display": "AVAILABLE",
+    "duedate": null
+  },
+  "barcode": "32044058883869",
+  "callNumber": "COL 985.5 HOY",
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": false,
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": "",
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": null,
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": null,
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "55",
+      "display": null
+    },
+    "62": {
+      "label": "Price",
+      "value": null,
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": null,
+      "display": null
+    },
+    "68": {
+      "label": "Last Checkin",
+      "value": null,
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": null,
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": null,
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": null,
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": null,
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "rchl",
+      "display": "OFFSITE - Request In Advance"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "231911262430003941",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": null,
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2022-06-27T03:54:29Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": null,
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "209",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "-",
+      "display": "AVAILABLE"
+    },
+    "93": {
+      "label": "Internal Use",
+      "value": null,
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": null,
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": null,
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": null,
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "2",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": null,
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": null,
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "209",
+      "display": "ReCAP - (DEFAULT)"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": null,
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": null,
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": null,
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": null,
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": null,
+      "marcTag": "876",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "p",
+          "content": "32044058883869"
+        },
+        {
+          "tag": "h",
+          "content": " "
+        },
+        {
+          "tag": "a",
+          "content": "231911262430003941"
+        },
+        {
+          "tag": "j",
+          "content": "Available"
+        },
+        {
+          "tag": "t",
+          "content": ""
+        },
+        {
+          "tag": "3",
+          "content": ""
+        },
+        {
+          "tag": "l",
+          "content": "HD"
+        },
+        {
+          "tag": "k",
+          "content": "LAW"
+        }
+      ]
+    },
+    {
+      "fieldTag": "a",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "COL 985.5 HOY"
+        },
+        {
+          "tag": "c",
+          "content": ""
+        },
+        {
+          "tag": "g",
+          "content": ""
+        },
+        {
+          "tag": "i",
+          "content": "32044058883869"
+        },
+        {
+          "tag": "l",
+          "content": "rchl"
+        },
+        {
+          "tag": "o",
+          "content": "2"
+        },
+        {
+          "tag": "s",
+          "content": "-"
+        },
+        {
+          "tag": "t",
+          "content": null
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "32044058883869",
+      "subfields": null
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "",
+      "subfields": null
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "900",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Shared"
+        },
+        {
+          "tag": "b",
+          "content": "HL"
+        }
+      ]
+    },
+    {
+      "fieldTag": null,
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "b",
+          "content": "LAW"
+        },
+        {
+          "tag": "c",
+          "content": "HD"
+        },
+        {
+          "tag": "h",
+          "content": "COL 985.5 HOY"
+        },
+        {
+          "tag": "0",
+          "content": "221911262450003941"
+        }
+      ]
+    }
+  ],
+  "nyplSource": "recap-hl",
+  "bibIds": [
+    "99154549873003941"
+  ]
+}

--- a/test/unit/es-item.test.js
+++ b/test/unit/es-item.test.js
@@ -273,6 +273,30 @@ describe('EsItem', function () {
         expect(esItem.recapCustomerCode()).to.deep.equal(['NA'])
       })
     })
+
+    describe('hl record in recap', function () {
+      it('should return the recapCustomerCode without prefix', function () {
+        const record = new SierraItem(require('../fixtures/item-hl-231730577470003941.json'))
+        const esItem = new EsItem(record)
+        expect(esItem.recapCustomerCode()).to.deep.equal(['HV'])
+      })
+    })
+
+    describe('hl record in hd', function () {
+      it('should return the recapCustomerCode with hd prefix', function () {
+        const record = new SierraItem(require('../fixtures/item-hl-231911262430003941.json'))
+        const esItem = new EsItem(record)
+        expect(esItem.recapCustomerCode()).to.deep.equal(['hd:HL'])
+      })
+    })
+
+    describe('PUL record in recap', function () {
+      it('should return the recapCustomerCode without prefix', function () {
+        const record = new SierraItem(require('../fixtures/item-pul-189241.json'))
+        const esItem = new EsItem(record)
+        expect(esItem.recapCustomerCode()).to.deep.equal(['PA'])
+      })
+    })
   })
 
   describe('requestable', function () {


### PR DESCRIPTION
Let's start adding hd: prefix to HD customer codes to address collision with recap customer codes

Related:
 - https://github.com/NYPL/nypl-core/pull/181
 - https://github.com/NYPL/nypl-core-objects/pull/58