### PR TITLE
SCC-5434: Move `collection` onto items

### DIFF
--- a/lib/es-models/bib.js
+++ b/lib/es-models/bib.js
@@ -151,21 +151,13 @@ class EsBib extends EsBase {
       )
       return match ? [match.code] : []
     }
-    // Translate item holdingLocations into plain ids:
-    const locationCodes = items.flatMap((item) => {
-      const loc = item.holdingLocation()
-      if (loc && loc.length) {
-        return loc[0].id.split(':').pop() // extract plain id
+
+    // Collect collection/division ids from items:
+    const collectionCodes = items.flatMap((item) => {
+      if (item.collection) {
+        return item.collection() || []
       }
       return []
-    })
-
-    // Translate into collection/division ids:
-    const collectionCodes = locationCodes.map((holdingId) => {
-      const entry = Object.values(nyplCore.collectionMapping()).find((c) =>
-        c.holdingLocations.includes(holdingId)
-      )
-      return entry ? entry.code : null
     })
       .filter(Boolean)
     return unique(collectionCodes)

--- a/lib/es-models/item.js
+++ b/lib/es-models/item.js
@@ -65,6 +65,23 @@ class EsItem extends BaseItemMixin(EsBase) {
     return pack(this.catalogItemType())
   }
 
+  /**
+   *  Get the collection/division ID for an item based on its holding location
+   */
+  collection () {
+    const loc = this.holdingLocation && this.holdingLocation()
+    if (loc && loc.length) {
+      const holdingId = loc[0].id.split(':').pop()
+      const entry = Object.values(nyplCore.collectionMapping()).find((c) =>
+        c.holdingLocations.includes(holdingId)
+      )
+      if (entry) {
+        return [entry.code]
+      }
+    }
+    return null
+  }
+
   dateRange () {
     const fieldtagV = this.item.fieldTag('v')[0]
     if (fieldtagV) {

--- a/test/unit/es-item.test.js
+++ b/test/unit/es-item.test.js
@@ -84,6 +84,24 @@ describe('EsItem', function () {
     })
   })
 
+  describe('collection', function () {
+    it('returns collection code based on item holding location', function () {
+      const record = new SierraItem(require('../fixtures/item-14441624.json'))
+      const esItem = new EsItem(record)
+      expect(esItem.collection()).to.deep.equal(['map'])
+    })
+
+    it('returns null if item holding location does not map to a collection', function () {
+      const fakeRecord = new SierraItem({
+        id: '1234',
+        nyplSource: 'sierra-nypl',
+        location: { code: 'zzzzz' }
+      })
+      const esItem = new EsItem(fakeRecord)
+      expect(esItem.collection()).to.equal(null)
+    })
+  })
+
   describe('enumerationChronology', function () {
     it('should return enumeration chronology', function () {
       const record = new SierraItem(require('../fixtures/item-17145801.json'))


### PR DESCRIPTION
context: with status messaging display updates AND lists, RC now needs to know collection ID mapped to item rather than just all the collections a bib is in. No change to bib unit tests since the `collection` field on the bib should be identical, it's just collecting the IDs from its items now
