### PR TITLE
Add automatic retrying for fetch in utils

### DIFF
--- a/lib/utils/nypl-source-mapper.js
+++ b/lib/utils/nypl-source-mapper.js
@@ -56,15 +56,24 @@ class NyplSourceMapper {
 const createInstance = async () => {
   const sourceMappingUrl = `https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'master'}/mappings/recap-discovery/nypl-source-mapping.json`
 
-  // Retrieve json file:
-  const resp = await fetch(sourceMappingUrl)
-    .catch((e) => {
-      throw new Error(`Error retrieving ${sourceMappingUrl}: ${e}`)
-    })
-
-  // Assert 2xx status:
-  if (!resp?.ok) {
-    throw new Error(`Error retrieving ${sourceMappingUrl} - got status ${resp?.status}`)
+  let resp
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      // Retrieve json file:
+      resp = await fetch(sourceMappingUrl)
+      // Assert 2xx status:
+      if (resp?.ok) break
+      throw new Error(`got status ${resp?.status}`)
+    } catch (err) {
+      if (attempt === 1) {
+        logger.warn(`First fetch attempt failed for ${sourceMappingUrl} (${err.message}). Retrying...`)
+      } else {
+        const msg = resp && !resp.ok
+          ? `Error retrieving ${sourceMappingUrl} - got status ${resp.status}`
+          : `Error retrieving ${sourceMappingUrl}: ${err.message}`
+        throw new Error(msg)
+      }
+    }
   }
 
   // Parse JSON:

--- a/lib/utils/nypl-source-mapper.js
+++ b/lib/utils/nypl-source-mapper.js
@@ -1,4 +1,6 @@
 const logger = require('../logger')
+const { retry } = require('./retry.js')
+
 class NyplSourceMapper {
   constructor (mapping) {
     this.nyplSourceMap = mapping
@@ -56,25 +58,13 @@ class NyplSourceMapper {
 const createInstance = async () => {
   const sourceMappingUrl = `https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'master'}/mappings/recap-discovery/nypl-source-mapping.json`
 
-  let resp
-  for (let attempt = 1; attempt <= 2; attempt++) {
-    try {
-      // Retrieve json file:
-      resp = await fetch(sourceMappingUrl)
-      // Assert 2xx status:
-      if (resp?.ok) break
-      throw new Error(`got status ${resp?.status}`)
-    } catch (err) {
-      if (attempt === 1) {
-        logger.warn(`First fetch attempt failed for ${sourceMappingUrl} (${err.message}). Retrying...`)
-      } else {
-        const msg = resp && !resp.ok
-          ? `Error retrieving ${sourceMappingUrl} - got status ${resp.status}`
-          : `Error retrieving ${sourceMappingUrl}: ${err.message}`
-        throw new Error(msg)
-      }
+  const resp = await retry(
+    async () => {
+      const res = await fetch(sourceMappingUrl)
+      if (res?.ok) return res
+      throw new Error(`got status ${res?.status}`)
     }
-  }
+  )()
 
   // Parse JSON:
   const data = await resp.json()

--- a/lib/utils/retry.js
+++ b/lib/utils/retry.js
@@ -14,6 +14,7 @@ const delay = (ms) => setTimeout(ms)
 
 const retry = (call, retries = 3) => {
   return async (error) => {
+    let lastError = error
     for (let i = 0; i < retries; i++) {
       const retryLabel = `Retry ${i + 1} of ${retries}`
       try {
@@ -21,15 +22,17 @@ const retry = (call, retries = 3) => {
         console.log(`${retryLabel}: Succeeded!`)
         return res
       } catch (e) {
+        lastError = e
         console.warn('Encountered error. Will retry:', e)
         const howLong = Math.pow(3, i + 1)
         console.log(`${retryLabel}: Waiting ${howLong}s`)
         await module.exports.delay(howLong * 1000)
       }
     }
-    console.error('Encountered error. Exhausted retries.', error)
+    console.error('Encountered error. Exhausted retries.', lastError)
     // Failed after 3 retries? Fail hard:
-    throw new Error(`Exhausted ${retries} retries`)
+    const errorMessage = lastError?.message || lastError || 'Unknown error'
+    throw new Error(`Exhausted ${retries} retries: ${errorMessage}`)
   }
 }
 

--- a/lib/utils/retry.js
+++ b/lib/utils/retry.js
@@ -1,0 +1,36 @@
+const { setTimeout } = require('node:timers/promises')
+
+const delay = (ms) => setTimeout(ms)
+
+/**
+* Retry an async call on error. Returns an async function that retries the
+* given call the given amount of times. Resolves when any call succeeds. Errors
+* when retries exhausted.
+*
+* Usage:
+*   doSomethingAsync()
+*     .catch(retry(doSomethingAsync, 3))
+**/
+
+const retry = (call, retries = 3) => {
+  return async (error) => {
+    for (let i = 0; i < retries; i++) {
+      const retryLabel = `Retry ${i + 1} of ${retries}`
+      try {
+        const res = await call()
+        console.log(`${retryLabel}: Succeeded!`)
+        return res
+      } catch (e) {
+        console.warn('Encountered error. Will retry:', e)
+        const howLong = Math.pow(3, i + 1)
+        console.log(`${retryLabel}: Waiting ${howLong}s`)
+        await module.exports.delay(howLong * 1000)
+      }
+    }
+    console.error('Encountered error. Exhausted retries.', error)
+    // Failed after 3 retries? Fail hard:
+    throw new Error(`Exhausted ${retries} retries`)
+  }
+}
+
+module.exports = { retry, delay }

--- a/scripts/update-property-by-csv.js
+++ b/scripts/update-property-by-csv.js
@@ -38,9 +38,10 @@ const {
   die,
   lineCount,
   printProgress,
-  retry,
   setAwsProfile
 } = require('./utils')
+
+const { retry } = require('../lib/utils/retry.js')
 
 /**
 * Parse script arguments from process.argv:

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -364,44 +364,6 @@ const lineCount = (file) => {
   })
 }
 
-/**
-* Retry an async call on error. Returns an async function that retries the
-* given call the given amount of times. Resolves when any call succeeds. Errors
-* when retries exhausted.
-*
-* Usage:
-*   doSomethingAsync()
-*     .catch(retry(doSomethingAsync, 3))
-**/
-const retry = (call, retries = 3, retryIndex = 0) => {
-  return async (error) => {
-    // Have we exhausted retries?
-    if (retryIndex === retries) {
-      console.error('Encountered error. Exhausted retries.', error)
-      // Failed after 3 retries? Fail hard:
-      throw new Error(`Exhausted ${retries} retries`)
-    }
-
-    console.error('Encountered error. Will retry:', error)
-    const retryLabel = `Retry ${retryIndex + 1} of ${retries}`
-    // Back off 3s, 9s, 27s:
-    const howLong = Math.pow(3, retryIndex + 1)
-    console.log(`${retryLabel}: Waiting ${howLong}s`)
-    await module.exports.delay(howLong * 1000)
-
-    // Execute call:
-    console.log(`${retryLabel}: Executing`)
-    return call()
-      // If retry succeeded, brag about it and return:
-      .then((res) => {
-        console.log(`${retryLabel}: Succeeded!`)
-        return res
-      })
-      // If call failed again, retry:
-      .catch(retry(call, retries, retryIndex + 1))
-  }
-}
-
 class Timer {
   constructor (name) {
     this.name = name
@@ -465,7 +427,6 @@ module.exports = {
   lineCount,
   printDiff,
   printProgress,
-  retry,
   secondsAsFriendlyDuration,
   setAwsProfile,
   Timer

--- a/test/unit/scripts-utils.test.js
+++ b/test/unit/scripts-utils.test.js
@@ -3,6 +3,8 @@ const sinon = require('sinon')
 
 const logger = require('../../lib/logger')
 const utils = require('../../scripts/utils')
+const retryUtils = require('../../lib/utils/retry.js')
+const { retry } = retryUtils
 
 describe('scripts/utils', () => {
   describe('batch', () => {
@@ -66,15 +68,17 @@ describe('scripts/utils', () => {
   describe('retry', () => {
     before(() => {
       sinon.stub(utils, 'delay').callsFake(() => Promise.resolve())
+      sinon.stub(retryUtils, 'delay').callsFake(() => Promise.resolve())
     })
 
     after(() => utils.delay.restore())
+    after(() => retryUtils.delay.restore())
 
     it('retries a failing function N times', async () => {
       const call = () => Promise.reject(new Error('Error!'))
 
-      await expect(call().catch(utils.retry(call, 1))).to.be.rejectedWith('Exhausted 1 retries')
-      await expect(call().catch(utils.retry(call, 3))).to.be.rejectedWith('Exhausted 3 retries')
+      await expect(call().catch(retry(call, 1))).to.be.rejectedWith('Exhausted 1 retries')
+      await expect(call().catch(retry(call, 3))).to.be.rejectedWith('Exhausted 3 retries')
     })
 
     it('resolves a temporarily failing function', async () => {
@@ -89,11 +93,11 @@ describe('scripts/utils', () => {
       }
 
       // First, confirm fails if only allowed to retry twice:
-      await expect(call().catch(utils.retry(call, 2))).to.be.rejectedWith('Exhausted 2 retries')
+      await expect(call().catch(retry(call, 2))).to.be.rejectedWith('Exhausted 2 retries')
 
       // Next, confirm it succeeds if allowed to retry thrice:
       errorCount = 0
-      await expect(call().catch(utils.retry(call, 3))).to.eventually.equal('toast')
+      await expect(call().catch(retry(call, 3))).to.eventually.equal('toast')
     })
   })
 

--- a/test/unit/utils-nypl-source-mapper.test.js
+++ b/test/unit/utils-nypl-source-mapper.test.js
@@ -1,5 +1,6 @@
 const expect = require('chai').expect
 const nock = require('nock')
+const sinon = require('sinon')
 
 const {
   stubNyplSourceMapper,
@@ -8,6 +9,7 @@ const {
 } = require('./utils')
 
 const NyplSourceMapper = require('../../lib/utils/nypl-source-mapper')
+const retryUtils = require('../../lib/utils/retry.js')
 
 const SOURCE_MAPPING_URL = 'https://raw.githubusercontent.com/NYPL/nypl-core/master/mappings/recap-discovery/nypl-source-mapping.json'
 
@@ -195,6 +197,9 @@ describe('utils/NyplSourceMapper', function () {
   })
 
   describe('nyplSourceMapping error conditions', async function () {
+    before(() => sinon.stub(retryUtils, 'delay').resolves())
+    after(() => retryUtils.delay.restore())
+
     beforeEach(() => NyplSourceMapper.__resetInstance())
     afterEach(() => {
       unstubNyplSourceMapper()
@@ -208,11 +213,11 @@ describe('utils/NyplSourceMapper', function () {
           'access-control-allow-credentials': 'true'
         })
         .get(/.*/)
-        .times(1)
+        .times(3)
         .reply(503, () => '{}')
 
       const call = NyplSourceMapper.loadInstance()
-      return expect(call).to.be.rejectedWith(`Error retrieving ${SOURCE_MAPPING_URL} - got status 503`)
+      return expect(call).to.be.rejectedWith('Exhausted 3 retries: got status 503')
     })
 
     it('should fail if mapping json returns a 200 but is malformed', async () => {


### PR DESCRIPTION
This was ticketed but not sure we every decided we definitely want to do this so feel free to weigh in.
This PR adds an automatic retry in case the fetch in `nypl-source-mapper` fails. It is intended to help quiet the alarms