### PR TITLE
Add 440 to series

### DIFF
--- a/lib/mappings/bib-mapping.json
+++ b/lib/mappings/bib-mapping.json
@@ -903,6 +903,12 @@
         "subfields": [
           "a"
         ]
+      },
+      {
+        "marc": "440",
+        "subfields": [
+          "a"
+        ]
       }
     ]
   },
@@ -910,6 +916,13 @@
     "paths": [
       {
         "marc": "490",
+        "excludedSubfields": [
+          "6"
+        ],
+        "subfieldJoiner": " "
+      },
+      {
+        "marc": "440",
         "excludedSubfields": [
           "6"
         ],


### PR DESCRIPTION
440 is a deprecated field but there are still some examples in the catalog, so we want to treat them the same way as 490 fields.