### PR TITLE
Add option to bulk-index to write to csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sam local invoke --profile nypl-digital-dev -t sam.local.yml -e test/sample-even
 
 The bulk-indexer can be used to index lots of records at once by direct BibService SQL query.
 
-For example, to reindex the first 10K NYPL bibs with marc 001 in QA:
+For example, to reindex the first 10K NYPL bibs in QA:
 ```
 node scripts/bulk-index.js --envfile config/qa-bulk-index.env --type bib --hasMarc 001 --nyplSource sierra-nypl --limit 10000
 ```

--- a/provisioning/base/resources.tf
+++ b/provisioning/base/resources.tf
@@ -65,12 +65,12 @@ resource "aws_lambda_function" "lambda_instance" {
   environment {
     variables = { for tuple in regexall("(.*?)=(.*)", file("../../config/${var.environment}.env")) : tuple[0] => tuple[1] }
   }
-  
+
   vpc_config {
     subnet_ids         = var.vpc_config.subnet_ids
     security_group_ids = var.vpc_config.security_group_ids
   }
-  
+
   tags = local.tags
 }
 
@@ -100,3 +100,21 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   tags = local.tags
 }
 
+resource "aws_cloudwatch_metric_alarm" "kinesis_iterator_age" {
+  alarm_name          = "lambda-kinesis-iterator-age-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "IteratorAge"
+  namespace           = "AWS/Lambda"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 60000 # Value in milliseconds (e.g., 60000ms = 60 seconds / 1 minute)
+  alarm_description   = "Triggered when Lambda Kinesis iterator age exceeds 1 minute"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.example.function_name
+  }
+
+  # Optional: Add your SNS topic ARN for notifications
+  # alarm_actions = [aws_sns_topic.example.arn]
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,6 +19,14 @@ This document is a work in progress and is nowhere near exhaustive. It is meant 
 * Risks: Low. 
   * Single record update using code that has passed code review and has been safely deployed.
 
+### `export-ids-by-marc.js`
+* Summary: Query the BibService or ItemService by MARC tag (and optionally subfield) and output the matching `id` and `nypl_source` to a CSV file.
+* Input: `--type (bib|item) --hasMarc [marc] --toCsv [output.csv]`
+* Uses:
+  * Collecting records to reindex via `bulk-index.js` by CSV when you need to reindex by a specific MARC field.
+* Risks: Low. 
+  * Queries are read-only.
+
 ### `bulk-index.js`
 * Summary: reindex any number of bibs using indexer code **currently checked out** on your machine, using data from specified environment, to live ES index from that environment
 * Input: csv of ids or bib service query. Note that it may be more efficient to run the bib service query separately and output to a csv with id and nyplSource column. If the property in question is a bib-level property, see documentation `bulk-index.js` about bib-only update invocations.
@@ -59,9 +67,10 @@ This case has two possible sources of bib ids:
   2. Bib service
     - A single marc field rule has been changed for a property that is comprised of multiple marc fields, AND that single marc field is not on every bib
     - Example: `subjectLiteral` ES property contains many 6xx fields. If recent updates only apply to uncommon 690 fields, every bib does not need to be updated, just the ones with 690 fields. Querying the bib service is the way to go here since the marc field is relevant.
-    - Example of SQL query for ids for bibs with a 690 marc field present, the output of which is written to a CSV:
+    - Example of using `export-ids-by-marc.js` to get bibs with a 690 marc field present, the output of which is written to a CSV:
     ```
-    \COPY (SELECT DISTINCT id, nypl_source FROM bib, json_array_elements(bib.var_fields::json) j690 WHERE jsonb_typeof(bib.var_fields) = 'array' AND j690->>'marcTag' = '690') TO '~/690_bibs.csv' WITH CSV DELIMITER ',' HEADER;
+    node scripts/export-ids-by-marc.js --envfile config/qa-bulk-index.env --type bib --hasMarc 690 --toCsv 690_bibs.csv
+    ```
 
 ## EC2
 If you are reindexing or updating more than a million or so records, it is a good idea to run the script from our dedicated server in AWS for long-running scripts. See documentation [here](https://docs.google.com/document/d/1A2PQt32tMmLRyI7KcTsOtheFMVvROt3akGdXuSXxwYQ/edit?tab=t.0#heading=h.njlhfusam8s0) for instructions.

--- a/scripts/bulk-index.js
+++ b/scripts/bulk-index.js
@@ -113,6 +113,7 @@ const argv = require('minimist')(process.argv.slice(2), {
   string: ['hasMarc', 'hasSubfield', 'bibId', 'fromDate', 'toDate'],
   integer: ['limit', 'offset', 'batchSize']
 })
+
 const { populateBarcodeRecapCustomerCodeCache } = require('../lib/scsb/requests')
 
 const isCalledViaCommandLine = /scripts\/bulk-index(.js)?/.test(fs.realpathSync(process.argv[1]))
@@ -522,8 +523,15 @@ const buildSqlQuery = (options) => {
 
   // Determine whether or not to use an inner-select to de-dupe the records:
   const dedupe = !!options.hasMarc
+  const toCsv = options.toCsv
 
-  const primaryColumns = dedupe ? 'DISTINCT id, nypl_source' : '*'
+  let primaryColumns = '*'
+  if (dedupe) {
+    primaryColumns = 'DISTINCT id, nypl_source'
+  }
+  if (toCsv) {
+    primaryColumns = 'id, nypl_source'
+  }
   let query = `SELECT ${primaryColumns} FROM ${sqlFromAndWhere}` +
     (options.orderBy ? ` ORDER BY ${options.orderBy}` : '') +
     (options.limit ? ` LIMIT ${options.limit}` : '') +
@@ -607,7 +615,11 @@ const updateByBibOrItemServiceQuery = async (options) => {
       let processed = false
       while (!processed && retries > 0) {
         try {
-          await indexer.processRecords(capitalize(type), records, { updateOnly: process.env.UPDATE_ONLY || argv.updateOnly, dryrun: argv.dryrun, skipDeletes: argv.skipDeletes })
+          if (options.toCsv) {
+            fs.appendFileSync(options.toCsv, rows.map(row => `${row.id},${row.nyplSource}\n`).join(''));
+          } else {
+            await indexer.processRecords(capitalize(type), records, { updateOnly: process.env.UPDATE_ONLY || argv.updateOnly, dryrun: argv.dryrun, skipDeletes: argv.skipDeletes })
+          }
           if (retries < 3) logger.info(`Succeeded on retry ${3 - retries}`)
           processed = true
         } catch (e) {

--- a/scripts/bulk-index.js
+++ b/scripts/bulk-index.js
@@ -45,18 +45,16 @@
  *
  *  I. Updating by Bib/Item Service query:
  *
- *    node scripts/bulk-index.js --type (item|bib) [--hasMarc MARC] [--hasSubfield S] [--nyplSource NYPLSOURCE]
+ *    node scripts/bulk-index.js --type (item|bib) [--nyplSource NYPLSOURCE]
  *
  *    Arguments:
- *      - hasMarc {string}: Marc tag that must be present in the record
- *      - hasSubfield {string}: When used with hasMarc, restricts to records matching both marc tag and subfield
  *      - orderBy {string}: Columns to order query by. Default '' (no sort).
  *        e.g. `--orderBy id`. Sortable columns include `id`, `updated_date`,
  *        `created_date`.
  *
  *    One of these mutually exclusive arguments must be used so that the script
  *    has something to query on:
- *     - hasMarc
+ *     - type
  *     - bibId
  *
  *    Note that omitting --limit may cause the query to take a long time to
@@ -67,12 +65,6 @@
  *    batch. (Otherwise, results are processed in an unstable order between jobs.)
  *
  *    Examples
- *
- *    To reindex all NYPL bibs with marc 001 in QA:
- *      node scripts/bulk-index.js --type bib --hasMarc 001
- *
- *    To reindex all NYPL bibs with 700 $t in QA:
- *      node scripts/bulk-index.js --type bib --hasMarc 700 --hasSubfield t
  *
  *    To reindex all bibs in QA:
  *      node scripts/bulk-index.js --type bib
@@ -110,7 +102,7 @@ const argv = require('minimist')(process.argv.slice(2), {
     updateOnly: false
   },
   boolean: ['updateOnly', 'skipDeletes'],
-  string: ['hasMarc', 'hasSubfield', 'bibId', 'fromDate', 'toDate'],
+  string: ['bibId', 'fromDate', 'toDate'],
   integer: ['limit', 'offset', 'batchSize']
 })
 
@@ -173,10 +165,8 @@ const usage = () => {
     'Usage:',
     'Reindex a single record:',
     '  node bulk-index --envfile [path to .env] (--bibId id|--itemId id)',
-    'Reindex by has-marc:',
-    '  node bulk-index --envfile [path to .env] --type (bib|item) --hasMarc 001 [--hasSubfield S]',
     'Reindex by nypl-source:',
-    '  node bulk-index --envfile [path to .env] --type (bib|item) --nyplSource SOURCE [--hasSubfield S]',
+    '  node bulk-index --envfile [path to .env] --type (bib|item) --nyplSource SOURCE',
     'Reindex by CSV (containing prefixed ids):',
     '  node bulk-index --envfile [path to .env] --csv FILE --csvIdColumn 0',
     'Perform any reindex only for specific bib-only properties by adding the following to any reindex args: ',
@@ -499,20 +489,6 @@ const buildSqlQuery = (options) => {
       params.push(options.nyplSource)
     }
 
-    // Filter on having a specific marc field:
-    if (options.hasMarc) {
-      selects.push('json_array_elements(var_fields::json) jV')
-      wheres.push("jV->>'marcTag' = $2")
-      params.push(options.hasMarc)
-    }
-
-    // Filter on existence of specific subfield:
-    if (options.hasSubfield) {
-      selects.push("json_array_elements(jV->'subfields') jVS")
-      wheres.push("jVS->>'tag' = $3")
-      params.push(options.hasSubfield)
-    }
-
     sqlFromAndWhere = selects.join(',\n')
     if (wheres.length) {
       sqlFromAndWhere += '\nWHERE ' + wheres.join('\nAND ')
@@ -521,30 +497,10 @@ const buildSqlQuery = (options) => {
     throw new Error('Insufficient options to buildSqlQuery')
   }
 
-  // Determine whether or not to use an inner-select to de-dupe the records:
-  const dedupe = !!options.hasMarc
-  const toCsv = options.toCsv
-
-  let primaryColumns = '*'
-  if (dedupe) {
-    primaryColumns = 'DISTINCT id, nypl_source'
-  }
-  if (toCsv) {
-    primaryColumns = 'id, nypl_source'
-  }
-  let query = `SELECT ${primaryColumns} FROM ${sqlFromAndWhere}` +
+  const query = `SELECT * FROM ${sqlFromAndWhere}` +
     (options.orderBy ? ` ORDER BY ${options.orderBy}` : '') +
     (options.limit ? ` LIMIT ${options.limit}` : '') +
     (options.offset ? ` OFFSET ${options.offset}` : '')
-  // Some queries will return bibs multiple times because a matched var/subfield repeats.
-  // To ensure we only handle such bibs once, we must de-deupe the results on id & nypl_source.
-  // We use an inner-select to identify all of the distinct bibs (by id and nypl_source)
-  // which we then JOIN to retrieve all fields.
-  if (dedupe) {
-    query = 'SELECT R.*' +
-      ` FROM (\n${query}\n) _R` +
-      ` INNER JOIN ${type} R ON _R.id=R.id AND _R.nypl_source=R.nypl_source`
-  }
 
   return { query, params, type }
 }
@@ -615,11 +571,7 @@ const updateByBibOrItemServiceQuery = async (options) => {
       let processed = false
       while (!processed && retries > 0) {
         try {
-          if (options.toCsv) {
-            fs.appendFileSync(options.toCsv, rows.map(row => `${row.id},${row.nyplSource}\n`).join(''))
-          } else {
-            await indexer.processRecords(capitalize(type), records, { updateOnly: process.env.UPDATE_ONLY || argv.updateOnly, dryrun: argv.dryrun, skipDeletes: argv.skipDeletes })
-          }
+          await indexer.processRecords(capitalize(type), records, { updateOnly: process.env.UPDATE_ONLY || argv.updateOnly, dryrun: argv.dryrun, skipDeletes: argv.skipDeletes })
           if (retries < 3) logger.info(`Succeeded on retry ${3 - retries}`)
           processed = true
         } catch (e) {
@@ -844,7 +796,6 @@ const run = async () => {
     (
       argv.type &&
       (
-        argv.hasMarc ||
         argv.nyplSource ||
         argv.fromDate
       )

--- a/scripts/bulk-index.js
+++ b/scripts/bulk-index.js
@@ -616,7 +616,7 @@ const updateByBibOrItemServiceQuery = async (options) => {
       while (!processed && retries > 0) {
         try {
           if (options.toCsv) {
-            fs.appendFileSync(options.toCsv, rows.map(row => `${row.id},${row.nyplSource}\n`).join(''));
+            fs.appendFileSync(options.toCsv, rows.map(row => `${row.id},${row.nyplSource}\n`).join(''))
           } else {
             await indexer.processRecords(capitalize(type), records, { updateOnly: process.env.UPDATE_ONLY || argv.updateOnly, dryrun: argv.dryrun, skipDeletes: argv.skipDeletes })
           }

--- a/scripts/export-ids-by-marc.js
+++ b/scripts/export-ids-by-marc.js
@@ -1,0 +1,181 @@
+/**
+ * Export IDs by MARC Query
+ *
+ * This script allows you to query the BibService or ItemService by MARC tag
+ * (and optionally subfield) and output the matching `id` and `nypl_source`
+ * to a CSV file.
+ *
+ * Usage:
+ *   node scripts/export-ids-by-marc.js --envfile [path to .env] --type (bib|item) --hasMarc 001 [--hasSubfield S] --toCsv [output.csv]
+ */
+
+const fs = require('fs')
+const argv = require('minimist')(process.argv.slice(2), {
+  default: {
+    batchSize: 1000,
+    nyplSource: 'sierra-nypl'
+  },
+  string: ['hasMarc', 'hasSubfield', 'type', 'toCsv', 'nyplSource', 'envfile'],
+  integer: ['limit', 'batchSize']
+})
+const dotenv = require('dotenv')
+const { Pool } = require('pg')
+const Cursor = require('pg-cursor')
+const kms = require('../lib/kms.js')
+const logger = require('../lib/logger')
+const { setAwsProfile, capitalize, printProgress, die } = require('./utils')
+
+const usage = () => {
+  console.log('Usage:')
+  console.log('  node scripts/export-ids-by-marc.js --envfile [path] --type (bib|item) --hasMarc [marc] --toCsv [output.csv]')
+  return true
+}
+
+const db = {
+  dbConnectionPools: null,
+  initPools: async () => {
+    db.dbConnectionPools = {
+      itemService: await db.initPool('ITEM'),
+      bibService: await db.initPool('BIB')
+    }
+  },
+  initPool: async (prefix) => {
+    const [user, password, host] = await Promise.all([
+      kms.decrypt(process.env[`${prefix}_SERVICE_DB_USER`]),
+      kms.decrypt(process.env[`${prefix}_SERVICE_DB_PW`]),
+      kms.decrypt(process.env[`${prefix}_SERVICE_DB_HOST`])
+    ])
+      .catch((e) => {
+        logger.error('Error decrypting db config. Be sure to specify an --envfile with encrypted db connection info.')
+        process.exit()
+      })
+    const config = {
+      user,
+      host,
+      database: process.env[`${prefix}_SERVICE_DB_NAME`],
+      password,
+      query_timeout: 1000 * 60 * 5
+    }
+    return new Pool(config)
+  },
+  connect: (name) => db.dbConnectionPools[name].connect(),
+  endPools: () => {
+    return Promise.all(
+      Object.values(db.dbConnectionPools).map((pool) => pool.end())
+    )
+  }
+}
+
+const buildSqlQuery = (options) => {
+  const type = options.type
+  const table = type
+
+  const selects = [table]
+  const wheres = []
+  const params = []
+
+  if (options.nyplSource && options.nyplSource !== 'all') {
+    params.push(options.nyplSource)
+    wheres.push(`nypl_source = $${params.length}`)
+  }
+
+  if (options.hasMarc) {
+    selects.push('json_array_elements(var_fields::json) jV')
+    params.push(options.hasMarc)
+    wheres.push(`jV->>'marcTag' = $${params.length}`)
+  }
+
+  if (options.hasSubfield) {
+    selects.push("json_array_elements(jV->'subfields') jVS")
+    params.push(options.hasSubfield)
+    wheres.push(`jVS->>'tag' = $${params.length}`)
+  }
+
+  let sqlFromAndWhere = selects.join(',\n')
+  if (wheres.length) {
+    sqlFromAndWhere += '\nWHERE ' + wheres.join('\nAND ')
+  }
+
+  let query = `SELECT DISTINCT id, nypl_source FROM ${sqlFromAndWhere}`
+  if (options.limit) {
+    query += ` LIMIT ${options.limit}`
+  }
+
+  return { query, params, type }
+}
+
+const readCursorRecurser = async (batchSize, cursor, retry = 1) => {
+  if (retry > 3) throw new Error('Error connecting to db after 3 tries')
+  try {
+    return await cursor.read(batchSize)
+  } catch (e) {
+    logger.warn('readCursorRecursor error: ', e)
+    logger.info(`readCursorRecursor retry #${retry}`)
+    return await readCursorRecurser(batchSize, cursor, ++retry)
+  }
+}
+
+const run = async () => {
+  setAwsProfile()
+  if (!argv.envfile) return usage() && die('--envfile required')
+  if (!argv.type) return usage() && die('--type required')
+  if (!['item', 'bib'].includes(argv.type)) return usage() && die('--type must be item or bib')
+  if (!argv.hasMarc) return usage() && die('--hasMarc required')
+  if (!argv.toCsv) return usage() && die('--toCsv required')
+
+  dotenv.config({ path: argv.envfile })
+  logger.setLevel(process.env.LOG_LEVEL || 'info')
+
+  await db.initPools()
+
+  const { query, params, type } = buildSqlQuery(argv)
+
+  logger.info(`Querying ${capitalize(type)}Service: ${query} | ${JSON.stringify(params)}`)
+  const client = await db.connect(`${type}Service`)
+  const cursor = client.query(new Cursor(query, params))
+
+  let count = 0
+  const startTime = new Date()
+  let done = false
+
+  while (!done && (!argv.limit || count < argv.limit)) {
+    let rows
+    try {
+      rows = await readCursorRecurser(argv.batchSize, cursor)
+    } catch (e) {
+      cursor.close(() => client.release())
+      throw e
+    }
+
+    if (rows.length === 0) {
+      logger.info(`Cursor reached the end. Stopping after ${count} processed.`)
+      done = true
+      break
+    }
+
+    fs.appendFileSync(argv.toCsv, rows.map(row => `${row.id},${row.nypl_source}\n`).join(''))
+    count += rows.length
+    printProgress(count, argv.limit, argv.batchSize, startTime)
+  }
+
+  await new Promise((resolve) => {
+    cursor.close(() => {
+      client.release()
+      resolve()
+    })
+  })
+  await db.endPools()
+}
+
+if (require.main === module) {
+  run()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      logger.error(e)
+      process.exit(1)
+    })
+}
+
+module.exports = {
+  buildSqlQuery
+}

--- a/test/unit/scripts-bulk-index.test.js
+++ b/test/unit/scripts-bulk-index.test.js
@@ -292,22 +292,6 @@ describe('scripts/bulk-index', () => {
         })
     })
 
-    it('builds sql for has-marc query', () => {
-      expect(bulkIndexer.buildSqlQuery({ hasMarc: '123', nyplSource: 'some-source', type: 'table_name' }))
-        .to.deep.eq({
-          query: [
-            'SELECT R.* FROM (',
-            'SELECT DISTINCT id, nypl_source FROM table_name,',
-            'json_array_elements(var_fields::json) jV',
-            'WHERE nypl_source = $1',
-            "AND jV->>'marcTag' = $2",
-            ') _R INNER JOIN table_name R ON _R.id=R.id AND _R.nypl_source=R.nypl_source'
-          ].join('\n'),
-          params: ['some-source', '123'],
-          type: 'table_name'
-        })
-    })
-
     it('builds sql for type query', () => {
       expect(bulkIndexer.buildSqlQuery({ type: 'table_name' }))
         .to.deep.eq({

--- a/test/unit/scripts-export-ids-by-marc.test.js
+++ b/test/unit/scripts-export-ids-by-marc.test.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai')
+
+const { buildSqlQuery } = require('../../scripts/export-ids-by-marc')
+
+describe('scripts/export-ids-by-marc', () => {
+  describe('buildSqlQuery', () => {
+    it('builds sql for has-marc query', () => {
+      expect(buildSqlQuery({ hasMarc: '001', nyplSource: 'sierra-nypl', type: 'bib' }))
+        .to.deep.eq({
+          query: [
+            'SELECT DISTINCT id, nypl_source FROM bib,',
+            'json_array_elements(var_fields::json) jV',
+            'WHERE nypl_source = $1',
+            "AND jV->>'marcTag' = $2"
+          ].join('\n'),
+          params: ['sierra-nypl', '001'],
+          type: 'bib'
+        })
+    })
+
+    it('builds sql for has-marc and has-subfield query', () => {
+      expect(buildSqlQuery({ hasMarc: '700', hasSubfield: 't', nyplSource: 'sierra-nypl', type: 'bib' }))
+        .to.deep.eq({
+          query: [
+            'SELECT DISTINCT id, nypl_source FROM bib,',
+            'json_array_elements(var_fields::json) jV,',
+            "json_array_elements(jV->'subfields') jVS",
+            'WHERE nypl_source = $1',
+            "AND jV->>'marcTag' = $2",
+            "AND jVS->>'tag' = $3"
+          ].join('\n'),
+          params: ['sierra-nypl', '700', 't'],
+          type: 'bib'
+        })
+    })
+
+    it('applies limit if specified', () => {
+      expect(buildSqlQuery({ hasMarc: '001', nyplSource: 'sierra-nypl', type: 'bib', limit: 10 }))
+        .to.deep.eq({
+          query: [
+            'SELECT DISTINCT id, nypl_source FROM bib,',
+            'json_array_elements(var_fields::json) jV',
+            'WHERE nypl_source = $1',
+            "AND jV->>'marcTag' = $2 LIMIT 10"
+          ].join('\n'),
+          params: ['sierra-nypl', '001'],
+          type: 'bib'
+        })
+    })
+  })
+})


### PR DESCRIPTION
Adds an option to bulk-index script to write to csv instead of writing to ES.
Want to do some more testing on this but also want to get thumbs up on this approach, since it is a little different from what the ticket says. The other possibility is to write this as a separate script and do some refactoring of common elements into a utility, but this issue with that is that there is more in common than not with the existing script. Let me know what you think